### PR TITLE
Navigation Routing 추가

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
@@ -8,6 +8,7 @@
 
 import ModernRIBs
 
+import CoreKit
 import AuthImplementations
 
 protocol AppRootInteractable: Interactable,
@@ -45,7 +46,7 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
         attachChild(loginRouting)
         
         let viewControllers = [
-            loginRouting.viewControllable
+            NavigationControllable(viewControllable: loginRouting.viewControllable)
         ]
         viewController.setViewControllers(viewControllers)
     }

--- a/client/Targets/Core/CoreKit/Sources/RIBsUtil/ViewControllable+Routing.swift
+++ b/client/Targets/Core/CoreKit/Sources/RIBsUtil/ViewControllable+Routing.swift
@@ -15,6 +15,22 @@ public extension ViewControllable {
         uiviewController.present(viewControllable.uiviewController, animated: animated, completion: completion)
     }
     
+    func pushViewController(_ viewControllable: ViewControllable, animated: Bool) {
+        if let navigationController = uiviewController as? UINavigationController {
+            navigationController.pushViewController(viewControllable.uiviewController, animated: animated)
+        } else {
+            uiviewController.navigationController?.pushViewController(viewControllable.uiviewController, animated: animated)
+        }
+    }
+    
+    func setViewControllers(_ viewControllables: [ViewControllable], animated: Bool) {
+        if let navigationController = uiviewController as? UINavigationController {
+            navigationController.setViewControllers(viewControllables.map(\.uiviewController), animated: animated)
+        } else {
+            uiviewController.navigationController?.setViewControllers(viewControllables.map(\.uiviewController), animated: animated)
+        }
+    }
+    
     func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
         uiviewController.dismiss(animated: animated, completion: completion)
     }

--- a/client/Targets/DesignSystem/DesignKit/Sources/Constants/Constants.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/Constants/Constants.swift
@@ -18,6 +18,7 @@ public extension Constants {
     static let cornerRadiusSmall: CGFloat = 8
     
     static let actionButtonHeight: CGFloat = 50
+    static let navigationViewHeight: CGFloat = 40
     
     static let imageWidthMedium: CGFloat = 180
     static let imageHegihtMedium: CGFloat = imageWidthMedium

--- a/client/Targets/DesignSystem/DesignKit/Sources/Views/NavigationView.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/Views/NavigationView.swift
@@ -86,11 +86,11 @@ public final class NavigationView: UIView {
     }
     
     public func showSeparator() {
-        separator.isHidden = true
+        separator.isHidden = false
     }
     
     public func hideSeparator() {
-        separator.isHidden = false
+        separator.isHidden = true
     }
     
 }

--- a/client/Targets/DesignSystem/DesignKit/Sources/Views/NavigationView.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/Views/NavigationView.swift
@@ -51,6 +51,13 @@ public final class NavigationView: UIView {
         return stackView
     }()
     
+    private let separator: UIView = {
+        let view = UIView()
+        view.backgroundColor = .hpGray4
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
@@ -78,13 +85,21 @@ public final class NavigationView: UIView {
         titleLabel.text = title
     }
     
+    public func showSeparator() {
+        separator.isHidden = true
+    }
+    
+    public func hideSeparator() {
+        separator.isHidden = false
+    }
+    
 }
 
 private extension NavigationView {
     
     func setupViews() {
         backgroundColor = .white
-        [titleLabel, leftButton, rightButtonStackView].forEach(addSubview)
+        [titleLabel, leftButton, rightButtonStackView, separator].forEach(addSubview)
         
         NSLayoutConstraint.activate([
             titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -94,7 +109,12 @@ private extension NavigationView {
             leftButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             
             rightButtonStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.traillingOffset),
-            rightButtonStackView.centerYAnchor.constraint(equalTo: centerYAnchor)
+            rightButtonStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            
+            separator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separator.bottomAnchor.constraint(equalTo: bottomAnchor),
+            separator.heightAnchor.constraint(equalToConstant: 1)
         ])
     }
     

--- a/client/Targets/Presentation/Auth/Implementations/Sources/Login/LoginInteractor.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/Login/LoginInteractor.swift
@@ -14,6 +14,7 @@ import DomainInterfaces
 
 protocol LoginRouting: ViewableRouting {
     func attachSignUp()
+    func detachSignUp()
 }
 
 protocol LoginPresentable: Presentable {
@@ -57,7 +58,6 @@ final class LoginInteractor: PresentableInteractor<LoginPresentable>, LoginInter
 
     override func willResignActive() {
         super.willResignActive()
-        
     }
     
     func naverButtonDidTap() {
@@ -67,4 +67,11 @@ final class LoginInteractor: PresentableInteractor<LoginPresentable>, LoginInter
     func appleButtonDidTap() {
         
     }
+    
+    // MARK: - SignUp
+    
+    func signUpDidTapClose() {
+        router?.detachSignUp()
+    }
+    
 }

--- a/client/Targets/Presentation/Auth/Implementations/Sources/Login/LoginRouter.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/Login/LoginRouter.swift
@@ -7,6 +7,7 @@
 //
 
 import ModernRIBs
+import CoreKit
 
 protocol LoginInteractable: Interactable, SignUpListener {
     var router: LoginRouting? { get set }
@@ -30,12 +31,18 @@ final class LoginRouter: ViewableRouter<LoginInteractable, LoginViewControllable
     
     func attachSignUp() {
         guard signUpRouter == nil else { return }
-        
         let router = signUpBuilder.build(withListener: interactor)
         attachChild(router)
         signUpRouter = router
         
-        router.viewControllable.uiviewController.modalPresentationStyle = .fullScreen
-        viewControllable.uiviewController.present(router.viewControllable.uiviewController, animated: true)
+        viewControllable.pushViewController(router.viewControllable, animated: true)
     }
+    
+    func detachSignUp() {
+        guard let router = signUpRouter else { return }
+        detachChild(router)
+        signUpRouter = nil
+        viewControllable.popViewController(animated: true)
+    }
+    
 }

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpInteractor.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpInteractor.swift
@@ -21,7 +21,7 @@ protocol SignUpPresentable: Presentable {
 }
 
 protocol SignUpListener: AnyObject {
-    // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
+    func signUpDidTapClose()
 }
 
 final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpInteractable, SignUpPresentableListener {
@@ -63,6 +63,10 @@ final class SignUpInteractor: PresentableInteractor<SignUpPresentable>, SignUpIn
             return
         }
         isSignUpEnabledSubject.send(!nickname.isEmpty)
+    }
+    
+    func didTapClose() {
+        listener?.signUpDidTapClose()
     }
     
 }

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpViewController.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpViewController.swift
@@ -20,6 +20,7 @@ protocol SignUpPresentableListener: AnyObject {
     func profileImageViewDidChange(_ imageData: Data)
     func signUpButtonDidTap()
     func signUpNicknameDidChange(_ nickname: String?)
+    func didTapClose()
 }
 
 final class SignUpViewController: UIViewController, SignUpPresentable, SignUpViewControllable {
@@ -27,6 +28,14 @@ final class SignUpViewController: UIViewController, SignUpPresentable, SignUpVie
     weak var listener: SignUpPresentableListener?
     
     private var cancellables = Set<AnyCancellable>()
+    
+    private lazy var navigationView: NavigationView = {
+        let navigationView = NavigationView()
+        navigationView.setup(model: .init(title: "회원가입", leftButtonType: .back, rightButtonTypes: []))
+        navigationView.delegate = self
+        navigationView.translatesAutoresizingMaskIntoConstraints = false
+        return navigationView
+    }()
     
     private lazy var profileImageView: UIImageView = {
         let imageView: UIImageView = .init(image: .profileDefault)
@@ -117,11 +126,16 @@ private extension SignUpViewController {
         
         view.backgroundColor = .hpWhite
         
-        [profileImageView, nicknameLabel, nicknameTextField, signUpButton].forEach { view.addSubview($0) }
+        [navigationView, profileImageView, nicknameLabel, nicknameTextField, signUpButton].forEach { view.addSubview($0) }
         
         NSLayoutConstraint.activate([
+            navigationView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationView.heightAnchor.constraint(equalToConstant: Constants.navigationViewHeight),
+            
             profileImageView.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
-            profileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: padding),
+            profileImageView.topAnchor.constraint(equalTo: navigationView.bottomAnchor, constant: padding),
             profileImageView.widthAnchor.constraint(equalToConstant: profileImageWidthHeight),
             profileImageView.heightAnchor.constraint(equalToConstant: profileImageWidthHeight),
             
@@ -171,6 +185,14 @@ extension SignUpViewController: PHPickerViewControllerDelegate {
         } else {
             // TODO: Handle empty results or item provider not being able load UIImage
         }
+    }
+    
+}
+
+extension SignUpViewController: NavigationViewDelegate {
+    
+    func navigationViewButtonDidTap(_ view: NavigationView, type: NavigationViewButtonType) {
+        listener?.didTapClose()
     }
     
 }


### PR DESCRIPTION
## 🌁 배경
* #28
* 기존에 테스트를 위해 Present 했던 SignUp 화면을 Navigation Push 로 변경

## ✅ 수정 내역
* ViewControllable NavigationPush 추가
* Login-SignUp Navigation 연결

## ⚙️ 테스트 방법
* tuist fetch -> tuist generate -> 실행


## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/36e7eafa-7a1d-43d4-a0ef-89f6283b78d4




