### PR TITLE
Home UI 추가 (Empty Case)

### DIFF
--- a/client/Targets/DesignSystem/DesignKit/Sources/Buttons/ActionButtonStyle.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/Buttons/ActionButtonStyle.swift
@@ -11,12 +11,13 @@ import UIKit
 public enum ActionButtonStyle {
     
     case normal
+    case smallNormal
     case secondary
     case alert
     
     var textColor: UIColor {
         switch self {
-        case .normal: return .hpWhite
+        case .normal, .smallNormal: return .hpWhite
         case .secondary: return .hpBlack
         case .alert: return .hpWhite
         }
@@ -28,7 +29,7 @@ public enum ActionButtonStyle {
     
     var backgroundColor: UIColor {
         switch self {
-        case .normal: return .hpBlack
+        case .normal, .smallNormal: return .hpBlack
         case .secondary: return .hpGray5
         case .alert: return .hpRed1
         }
@@ -60,11 +61,23 @@ public enum ActionButtonStyle {
     }
     
     var font: UIFont {
-        return .bodySemibold
+        switch self {
+        case .smallNormal:
+            return .captionSemibold
+        default:
+            return .bodySemibold
+            
+        }
     }
     
     var disabledFont: UIFont {
-        return .bodySemibold
+        switch self {
+        case .smallNormal:
+            return .captionSemibold
+        default:
+            return .bodySemibold
+            
+        }
     }
     
 }

--- a/client/Targets/DesignSystem/DesignKit/Sources/Extensions/UIView+.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/Extensions/UIView+.swift
@@ -6,4 +6,16 @@
 //  Copyright © 2023 codesquad. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+public extension UIView {
+    
+    @discardableResult
+    func addTapGesture(target: Any?, action: Selector?) -> UITapGestureRecognizer {
+        let tapGesture = UITapGestureRecognizer(target: target, action: action)
+        isUserInteractionEnabled = true
+        addGestureRecognizer(tapGesture)
+        return tapGesture
+    }
+    
+}

--- a/client/Targets/DesignSystem/DesignKit/Sources/Extensions/UIView+.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/Extensions/UIView+.swift
@@ -1,0 +1,9 @@
+//
+//  UIView+.swift
+//  DesignKit
+//
+//  Created by 홍성준 on 11/14/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation

--- a/client/Targets/Presentation/Home/Demo/Sources/AppDelegate.swift
+++ b/client/Targets/Presentation/Home/Demo/Sources/AppDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import HomeImplementations
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -8,8 +9,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window
         let viewController = UIViewController()
-        viewController.view.backgroundColor = .systemPink
-        window.rootViewController = viewController
+        window.rootViewController = HomeViewController()
         window.makeKeyAndVisible()
         return true
     }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardBuilder.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardBuilder.swift
@@ -1,0 +1,33 @@
+//
+//  HomeFollowingDashboardBuilder.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeFollowingDashboardDependency: Dependency {}
+
+final class HomeFollowingDashboardComponent: Component<HomeFollowingDashboardDependency> {}
+
+protocol HomeFollowingDashboardBuildable: Buildable {
+    func build(withListener listener: HomeFollowingDashboardListener) -> HomeFollowingDashboardRouting
+}
+
+final class HomeFollowingDashboardBuilder: Builder<HomeFollowingDashboardDependency>, HomeFollowingDashboardBuildable {
+    
+    override init(dependency: HomeFollowingDashboardDependency) {
+        super.init(dependency: dependency)
+    }
+    
+    func build(withListener listener: HomeFollowingDashboardListener) -> HomeFollowingDashboardRouting {
+        let component = HomeFollowingDashboardComponent(dependency: dependency)
+        let viewController = HomeFollowingDashboardViewController()
+        let interactor = HomeFollowingDashboardInteractor(presenter: viewController)
+        interactor.listener = listener
+        return HomeFollowingDashboardRouter(interactor: interactor, viewController: viewController)
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardInteractor.swift
@@ -1,0 +1,37 @@
+//
+//  HomeFollowingDashboardInteractor.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeFollowingDashboardRouting: ViewableRouting {}
+
+protocol HomeFollowingDashboardPresentable: Presentable {
+    var listener: HomeFollowingDashboardPresentableListener? { get set }
+}
+
+protocol HomeFollowingDashboardListener: AnyObject {}
+
+final class HomeFollowingDashboardInteractor: PresentableInteractor<HomeFollowingDashboardPresentable>, HomeFollowingDashboardInteractable, HomeFollowingDashboardPresentableListener {
+
+    weak var router: HomeFollowingDashboardRouting?
+    weak var listener: HomeFollowingDashboardListener?
+    
+    override init(presenter: HomeFollowingDashboardPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardRouter.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardRouter.swift
@@ -1,0 +1,25 @@
+//
+//  HomeFollowingDashboardRouter.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeFollowingDashboardInteractable: Interactable {
+    var router: HomeFollowingDashboardRouting? { get set }
+    var listener: HomeFollowingDashboardListener? { get set }
+}
+
+protocol HomeFollowingDashboardViewControllable: ViewControllable {}
+
+final class HomeFollowingDashboardRouter: ViewableRouter<HomeFollowingDashboardInteractable, HomeFollowingDashboardViewControllable>, HomeFollowingDashboardRouting {
+    
+    override init(interactor: HomeFollowingDashboardInteractable, viewController: HomeFollowingDashboardViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardViewController.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardViewController.swift
@@ -1,5 +1,5 @@
 //
-//  HomeHotPlaceDashboardViewController.swift
+//  HomeFollowingDashboardViewController.swift
 //  HomeImplementations
 //
 //  Created by 홍성준 on 11/15/23.
@@ -10,16 +10,16 @@ import ModernRIBs
 import UIKit
 import DesignKit
 
-protocol HomeHotPlaceDashboardPresentableListener: AnyObject {}
+protocol HomeFollowingDashboardPresentableListener: AnyObject {}
 
-final class HomeHotPlaceDashboardViewController: UIViewController, HomeHotPlaceDashboardPresentable, HomeHotPlaceDashboardViewControllable {
-    
-    weak var listener: HomeHotPlaceDashboardPresentableListener?
+final class HomeFollowingDashboardViewController: UIViewController, HomeFollowingDashboardPresentable, HomeFollowingDashboardViewControllable {
+
+    weak var listener: HomeFollowingDashboardPresentableListener?
     
     private let titleView: HomeTitleView = {
         let titleView = HomeTitleView()
         titleView.setup(model: .init(
-            title: "핫플레이스",
+            title: "팔로잉",
             isButtonEnabled: false
         ))
         titleView.translatesAutoresizingMaskIntoConstraints = false
@@ -29,8 +29,8 @@ final class HomeHotPlaceDashboardViewController: UIViewController, HomeHotPlaceD
     private let emptyView: HomeEmptyView = {
         let emptyView = HomeEmptyView()
         emptyView.setup(model: .init(
-            title: "핫플레이가 없어요",
-            subtitle: "{업데이트 되는 일정}에 업데이트 되어요"
+            title: "팔로잉이 없어요",
+            subtitle: "새로운 친구를 추가해보세요"
         ))
         emptyView.translatesAutoresizingMaskIntoConstraints = false
         return emptyView
@@ -40,9 +40,10 @@ final class HomeHotPlaceDashboardViewController: UIViewController, HomeHotPlaceD
         super.viewDidLoad()
         setupViews()
     }
+    
 }
 
-private extension HomeHotPlaceDashboardViewController {
+private extension HomeFollowingDashboardViewController {
     
     func setupViews() {
         view.addSubview(titleView)

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeBuilder.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeBuilder.swift
@@ -10,18 +10,23 @@ import ModernRIBs
 
 public protocol HomeDependency: Dependency {}
 
-final class HomeComponent: Component<HomeDependency>, HomeRecommendDashboardDependency, HomeHotPlaceDashboardDependency {}
+final class HomeComponent: Component<HomeDependency>,
+                           HomeRecommendDashboardDependency,
+                           HomeHotPlaceDashboardDependency,
+                           HomeFollowingDashboardDependency {
+    
+}
 
 public protocol HomeBuildable: Buildable {
     func build(withListener listener: HomeListener) -> ViewableRouting
 }
 
 public final class HomeBuilder: Builder<HomeDependency>, HomeBuildable {
-
+    
     public override init(dependency: HomeDependency) {
         super.init(dependency: dependency)
     }
-
+    
     public func build(withListener listener: HomeListener) -> ViewableRouting {
         let component = HomeComponent(dependency: dependency)
         let viewController = HomeViewController()
@@ -30,12 +35,14 @@ public final class HomeBuilder: Builder<HomeDependency>, HomeBuildable {
         
         let recommendDashboardBuilder = HomeRecommendDashboardBuilder(dependency: component)
         let hotPlaceDashboardBuilder = HomeHotPlaceDashboardBuilder(dependency: component)
+        let followingDashboardBuilder = HomeFollowingDashboardBuilder(dependency: component)
         
         return HomeRouter(
             interactor: interactor,
             viewController: viewController,
             recommendDashboardBuilder: recommendDashboardBuilder,
-            hotPlaceDashboardBuilder: hotPlaceDashboardBuilder
+            hotPlaceDashboardBuilder: hotPlaceDashboardBuilder,
+            followingDashboardBuilder: followingDashboardBuilder
         )
     }
 }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeBuilder.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeBuilder.swift
@@ -10,7 +10,7 @@ import ModernRIBs
 
 public protocol HomeDependency: Dependency {}
 
-final class HomeComponent: Component<HomeDependency> {}
+final class HomeComponent: Component<HomeDependency>, HomeRecommendDashboardDependency {}
 
 public protocol HomeBuildable: Buildable {
     func build(withListener listener: HomeListener) -> ViewableRouting
@@ -27,6 +27,13 @@ public final class HomeBuilder: Builder<HomeDependency>, HomeBuildable {
         let viewController = HomeViewController()
         let interactor = HomeInteractor(presenter: viewController)
         interactor.listener = listener
-        return HomeRouter(interactor: interactor, viewController: viewController)
+        
+        let recommendDashboardBuilder = HomeRecommendDashboardBuilder(dependency: component)
+        
+        return HomeRouter(
+            interactor: interactor,
+            viewController: viewController,
+            recommendDashboardBuilder: recommendDashboardBuilder
+        )
     }
 }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeBuilder.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeBuilder.swift
@@ -10,7 +10,7 @@ import ModernRIBs
 
 public protocol HomeDependency: Dependency {}
 
-final class HomeComponent: Component<HomeDependency>, HomeRecommendDashboardDependency {}
+final class HomeComponent: Component<HomeDependency>, HomeRecommendDashboardDependency, HomeHotPlaceDashboardDependency {}
 
 public protocol HomeBuildable: Buildable {
     func build(withListener listener: HomeListener) -> ViewableRouting
@@ -29,11 +29,13 @@ public final class HomeBuilder: Builder<HomeDependency>, HomeBuildable {
         interactor.listener = listener
         
         let recommendDashboardBuilder = HomeRecommendDashboardBuilder(dependency: component)
+        let hotPlaceDashboardBuilder = HomeHotPlaceDashboardBuilder(dependency: component)
         
         return HomeRouter(
             interactor: interactor,
             viewController: viewController,
-            recommendDashboardBuilder: recommendDashboardBuilder
+            recommendDashboardBuilder: recommendDashboardBuilder,
+            hotPlaceDashboardBuilder: hotPlaceDashboardBuilder
         )
     }
 }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
@@ -8,10 +8,13 @@
 
 import ModernRIBs
 
-protocol HomeRouting: ViewableRouting {}
+protocol HomeRouting: ViewableRouting {
+    func attachRecommendDashboard()
+}
 
 protocol HomePresentable: Presentable {
     var listener: HomePresentableListener? { get set }
+    func setDashboard(_ viewControllable: ViewControllable)
 }
 
 public protocol HomeListener: AnyObject {}
@@ -28,6 +31,7 @@ final class HomeInteractor: PresentableInteractor<HomePresentable>, HomeInteract
 
     override func didBecomeActive() {
         super.didBecomeActive()
+        router?.attachRecommendDashboard()
     }
 
     override func willResignActive() {

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
@@ -11,6 +11,7 @@ import ModernRIBs
 protocol HomeRouting: ViewableRouting {
     func attachRecommendDashboard()
     func attachHotPlaceDashboard()
+    func attachFollowingDashboard()
 }
 
 protocol HomePresentable: Presentable {
@@ -34,6 +35,7 @@ final class HomeInteractor: PresentableInteractor<HomePresentable>, HomeInteract
         super.didBecomeActive()
         router?.attachRecommendDashboard()
         router?.attachHotPlaceDashboard()
+        router?.attachFollowingDashboard()
     }
 
     override func willResignActive() {

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
@@ -10,6 +10,7 @@ import ModernRIBs
 
 protocol HomeRouting: ViewableRouting {
     func attachRecommendDashboard()
+    func attachHotPlaceDashboard()
 }
 
 protocol HomePresentable: Presentable {
@@ -32,6 +33,7 @@ final class HomeInteractor: PresentableInteractor<HomePresentable>, HomeInteract
     override func didBecomeActive() {
         super.didBecomeActive()
         router?.attachRecommendDashboard()
+        router?.attachHotPlaceDashboard()
     }
 
     override func willResignActive() {

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeRouter.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeRouter.swift
@@ -8,7 +8,7 @@
 
 import ModernRIBs
 
-protocol HomeInteractable: Interactable, HomeRecommendDashboardListener, HomeHotPlaceDashboardListener {
+protocol HomeInteractable: Interactable, HomeRecommendDashboardListener, HomeHotPlaceDashboardListener, HomeFollowingDashboardListener {
     var router: HomeRouting? { get set }
     var listener: HomeListener? { get set }
 }
@@ -24,15 +24,20 @@ final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable>, 
     
     private let hotPlaceDashboardBuilder: HomeHotPlaceDashboardBuildable
     private var hotPlaceDashboardRouting: Routing?
+   
+    private let followingDashboardBuilder: HomeFollowingDashboardBuildable
+    private var followingDashboardRouting: Routing?
     
     init(
         interactor: HomeInteractable, 
         viewController: HomeViewControllable,
         recommendDashboardBuilder: HomeRecommendDashboardBuildable,
-        hotPlaceDashboardBuilder: HomeHotPlaceDashboardBuildable
+        hotPlaceDashboardBuilder: HomeHotPlaceDashboardBuildable,
+        followingDashboardBuilder: HomeFollowingDashboardBuildable
     ) {
         self.recommendDashboardBuilder = recommendDashboardBuilder
         self.hotPlaceDashboardBuilder = hotPlaceDashboardBuilder
+        self.followingDashboardBuilder = followingDashboardBuilder
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
     }
@@ -50,6 +55,14 @@ final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable>, 
         let router = hotPlaceDashboardBuilder.build(withListener: interactor)
         viewController.setDashboard(router.viewControllable)
         self.hotPlaceDashboardRouting = router
+        attachChild(router)
+    }
+    
+    func attachFollowingDashboard() {
+        guard followingDashboardRouting == nil else { return }
+        let router = followingDashboardBuilder.build(withListener: interactor)
+        viewController.setDashboard(router.viewControllable)
+        self.followingDashboardRouting = router
         attachChild(router)
     }
     

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeRouter.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeRouter.swift
@@ -8,17 +8,36 @@
 
 import ModernRIBs
 
-protocol HomeInteractable: Interactable {
+protocol HomeInteractable: Interactable, HomeRecommendDashboardListener {
     var router: HomeRouting? { get set }
     var listener: HomeListener? { get set }
 }
 
-protocol HomeViewControllable: ViewControllable {}
+protocol HomeViewControllable: ViewControllable {
+    func setDashboard(_ viewControllable: ViewControllable)
+}
 
 final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable>, HomeRouting {
     
-    override init(interactor: HomeInteractable, viewController: HomeViewControllable) {
+    private let recommendDashboardBuilder: HomeRecommendDashboardBuildable
+    private var recommendDashboardRouting: Routing?
+    
+    init(
+        interactor: HomeInteractable, 
+        viewController: HomeViewControllable,
+        recommendDashboardBuilder: HomeRecommendDashboardBuildable
+    ) {
+        self.recommendDashboardBuilder = recommendDashboardBuilder
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
     }
+    
+    func attachRecommendDashboard() {
+        guard recommendDashboardRouting == nil else { return }
+        let router = recommendDashboardBuilder.build(withListener: interactor)
+        viewController.setDashboard(router.viewControllable)
+        self.recommendDashboardRouting = router
+        attachChild(router)
+    }
+    
 }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeRouter.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeRouter.swift
@@ -8,7 +8,7 @@
 
 import ModernRIBs
 
-protocol HomeInteractable: Interactable, HomeRecommendDashboardListener {
+protocol HomeInteractable: Interactable, HomeRecommendDashboardListener, HomeHotPlaceDashboardListener {
     var router: HomeRouting? { get set }
     var listener: HomeListener? { get set }
 }
@@ -22,12 +22,17 @@ final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable>, 
     private let recommendDashboardBuilder: HomeRecommendDashboardBuildable
     private var recommendDashboardRouting: Routing?
     
+    private let hotPlaceDashboardBuilder: HomeHotPlaceDashboardBuildable
+    private var hotPlaceDashboardRouting: Routing?
+    
     init(
         interactor: HomeInteractable, 
         viewController: HomeViewControllable,
-        recommendDashboardBuilder: HomeRecommendDashboardBuildable
+        recommendDashboardBuilder: HomeRecommendDashboardBuildable,
+        hotPlaceDashboardBuilder: HomeHotPlaceDashboardBuildable
     ) {
         self.recommendDashboardBuilder = recommendDashboardBuilder
+        self.hotPlaceDashboardBuilder = hotPlaceDashboardBuilder
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
     }
@@ -37,6 +42,14 @@ final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable>, 
         let router = recommendDashboardBuilder.build(withListener: interactor)
         viewController.setDashboard(router.viewControllable)
         self.recommendDashboardRouting = router
+        attachChild(router)
+    }
+    
+    func attachHotPlaceDashboard() {
+        guard hotPlaceDashboardRouting == nil else { return }
+        let router = hotPlaceDashboardBuilder.build(withListener: interactor)
+        viewController.setDashboard(router.viewControllable)
+        self.hotPlaceDashboardRouting = router
         attachChild(router)
     }
     

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeViewController.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeViewController.swift
@@ -12,29 +12,46 @@ import ModernRIBs
 
 protocol HomePresentableListener: AnyObject {}
 
-final class HomeViewController: UIViewController, HomePresentable, HomeViewControllable {
+public final class HomeViewController: UIViewController, HomePresentable, HomeViewControllable {
     
     private enum Constant {
         static let tabBarTitle = "홈"
         static let tabBarImage = "house"
         static let tabBarImageSelected = "house.fill"
     }
-
+    
     weak var listener: HomePresentableListener?
     
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 40
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         setupTabBar()
     }
     
-    required init?(coder: NSCoder) {
+    required public init?(coder: NSCoder) {
         super.init(coder: coder)
         setupTabBar()
     }
     
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
+    }
+    
+    func setDashboard(_ viewControllable: ViewControllable) {
+        let viewController = viewControllable.uiviewController
+        addChild(viewController)
+        stackView.addArrangedSubview(viewController.view)
+        viewController.didMove(toParent: self)
     }
     
 }
@@ -43,6 +60,13 @@ private extension HomeViewController {
     
     func setupViews() {
         view.backgroundColor = .hpWhite
+        view.addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
     }
     
     func setupTabBar() {

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardBuilder.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardBuilder.swift
@@ -1,0 +1,32 @@
+//
+//  HomeHotPlaceDashboardBuilder.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeHotPlaceDashboardDependency: Dependency {}
+
+final class HomeHotPlaceDashboardComponent: Component<HomeHotPlaceDashboardDependency> {}
+
+protocol HomeHotPlaceDashboardBuildable: Buildable {
+    func build(withListener listener: HomeHotPlaceDashboardListener) -> HomeHotPlaceDashboardRouting
+}
+
+final class HomeHotPlaceDashboardBuilder: Builder<HomeHotPlaceDashboardDependency>, HomeHotPlaceDashboardBuildable {
+
+    override init(dependency: HomeHotPlaceDashboardDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: HomeHotPlaceDashboardListener) -> HomeHotPlaceDashboardRouting {
+        let component = HomeHotPlaceDashboardComponent(dependency: dependency)
+        let viewController = HomeHotPlaceDashboardViewController()
+        let interactor = HomeHotPlaceDashboardInteractor(presenter: viewController)
+        interactor.listener = listener
+        return HomeHotPlaceDashboardRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardInteractor.swift
@@ -1,0 +1,37 @@
+//
+//  HomeHotPlaceDashboardInteractor.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeHotPlaceDashboardRouting: ViewableRouting {}
+
+protocol HomeHotPlaceDashboardPresentable: Presentable {
+    var listener: HomeHotPlaceDashboardPresentableListener? { get set }
+}
+
+protocol HomeHotPlaceDashboardListener: AnyObject {}
+
+final class HomeHotPlaceDashboardInteractor: PresentableInteractor<HomeHotPlaceDashboardPresentable>, HomeHotPlaceDashboardInteractable, HomeHotPlaceDashboardPresentableListener {
+
+    weak var router: HomeHotPlaceDashboardRouting?
+    weak var listener: HomeHotPlaceDashboardListener?
+    
+    override init(presenter: HomeHotPlaceDashboardPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardRouter.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardRouter.swift
@@ -1,0 +1,25 @@
+//
+//  HomeHotPlaceDashboardRouter.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeHotPlaceDashboardInteractable: Interactable {
+    var router: HomeHotPlaceDashboardRouting? { get set }
+    var listener: HomeHotPlaceDashboardListener? { get set }
+}
+
+protocol HomeHotPlaceDashboardViewControllable: ViewControllable {}
+
+final class HomeHotPlaceDashboardRouter: ViewableRouter<HomeHotPlaceDashboardInteractable, HomeHotPlaceDashboardViewControllable>, HomeHotPlaceDashboardRouting {
+    
+    override init(interactor: HomeHotPlaceDashboardInteractable, viewController: HomeHotPlaceDashboardViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardViewController.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardViewController.swift
@@ -1,0 +1,64 @@
+//
+//  HomeHotPlaceDashboardViewController.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+import UIKit
+import DesignKit
+
+protocol HomeHotPlaceDashboardPresentableListener: AnyObject {}
+
+final class HomeHotPlaceDashboardViewController: UIViewController, HomeHotPlaceDashboardPresentable, HomeHotPlaceDashboardViewControllable {
+    
+    weak var listener: HomeHotPlaceDashboardPresentableListener?
+    
+    private let titleView: HomeTitleView = {
+        let titleView = HomeTitleView()
+        titleView.setup(model: .init(
+            title: "핫플레이스",
+            isButtonEnabled: false
+        ))
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        return titleView
+    }()
+    
+    private let emptyView: HomeEmptyView = {
+        let emptyView = HomeEmptyView()
+        emptyView.setup(model: .init(
+            title: "핫플레이가 없어요",
+            subtitle: "{업데이트 되는 일정}에 업데이트 되어요"
+        ))
+        emptyView.translatesAutoresizingMaskIntoConstraints = false
+        return emptyView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViews()
+    }
+}
+
+
+private extension HomeHotPlaceDashboardViewController {
+    
+    func setupViews() {
+        view.addSubview(titleView)
+        view.addSubview(emptyView)
+        
+        NSLayoutConstraint.activate([
+            titleView.topAnchor.constraint(equalTo: view.topAnchor),
+            titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
+            titleView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
+            
+            emptyView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: 20),
+            emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
+            emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
+            emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardBuilder.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardBuilder.swift
@@ -1,0 +1,31 @@
+//
+//  HomeRecommendDashboardBuilder.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeRecommendDashboardDependency: Dependency {}
+
+final class HomeRecommendDashboardComponent: Component<HomeRecommendDashboardDependency> {}
+
+protocol HomeRecommendDashboardBuildable: Buildable {
+    func build(withListener listener: HomeRecommendDashboardListener) -> ViewableRouting
+}
+
+final class HomeRecommendDashboardBuilder: Builder<HomeRecommendDashboardDependency>, HomeRecommendDashboardBuildable {
+    
+    override init(dependency: HomeRecommendDashboardDependency) {
+        super.init(dependency: dependency)
+    }
+    
+    func build(withListener listener: HomeRecommendDashboardListener) -> ViewableRouting {
+        let viewController = HomeRecommendDashboardViewController()
+        let interactor = HomeRecommendDashboardInteractor(presenter: viewController)
+        interactor.listener = listener
+        return HomeRecommendDashboardRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardInteractor.swift
@@ -1,0 +1,36 @@
+//
+//  HomeRecommendDashboardInteractor.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeRecommendDashboardRouting: ViewableRouting {}
+
+protocol HomeRecommendDashboardPresentable: Presentable {
+    var listener: HomeRecommendDashboardPresentableListener? { get set }
+}
+
+protocol HomeRecommendDashboardListener: AnyObject {}
+
+final class HomeRecommendDashboardInteractor: PresentableInteractor<HomeRecommendDashboardPresentable>, HomeRecommendDashboardInteractable, HomeRecommendDashboardPresentableListener {
+
+    weak var router: HomeRecommendDashboardRouting?
+    weak var listener: HomeRecommendDashboardListener?
+
+    override init(presenter: HomeRecommendDashboardPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+    }
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardRouter.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardRouter.swift
@@ -1,0 +1,25 @@
+//
+//  HomeRecommendDashboardRouter.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol HomeRecommendDashboardInteractable: Interactable {
+    var router: HomeRecommendDashboardRouting? { get set }
+    var listener: HomeRecommendDashboardListener? { get set }
+}
+
+protocol HomeRecommendDashboardViewControllable: ViewControllable {}
+
+final class HomeRecommendDashboardRouter: ViewableRouter<HomeRecommendDashboardInteractable, HomeRecommendDashboardViewControllable>, HomeRecommendDashboardRouting {
+    
+    override init(interactor: HomeRecommendDashboardInteractable, viewController: HomeRecommendDashboardViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardViewController.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardViewController.swift
@@ -1,0 +1,64 @@
+//
+//  HomeRecommendDashboardViewController.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+import UIKit
+import DesignKit
+
+protocol HomeRecommendDashboardPresentableListener: AnyObject {}
+
+final class HomeRecommendDashboardViewController: UIViewController, HomeRecommendDashboardPresentable, HomeRecommendDashboardViewControllable {
+    
+    weak var listener: HomeRecommendDashboardPresentableListener?
+    
+    private let titleView: HomeTitleView = {
+        let titleView = HomeTitleView()
+        titleView.setup(model: .init(
+            title: "강남구 추천 장소", 
+            isButtonEnabled: false
+        ))
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        return titleView
+    }()
+    
+    private let emptyView: HomeEmptyView = {
+        let emptyView = HomeEmptyView()
+        emptyView.setup(model: .init(
+            title: "추천 장소가 없어요",
+            subtitle: "스토리를 작성하시면 추천 장소가 될 수 있어요"
+        ))
+        emptyView.translatesAutoresizingMaskIntoConstraints = false
+        return emptyView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViews()
+    }
+    
+}
+
+private extension HomeRecommendDashboardViewController {
+    
+    func setupViews() {
+        view.addSubview(titleView)
+        view.addSubview(emptyView)
+        
+        NSLayoutConstraint.activate([
+            titleView.topAnchor.constraint(equalTo: view.topAnchor),
+            titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
+            titleView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
+            
+            emptyView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: 20),
+            emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
+            emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
+            emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/Views/HomeEmptyView.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/Views/HomeEmptyView.swift
@@ -1,0 +1,90 @@
+//
+//  HomeEmptyView.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/14/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import DesignKit
+
+struct HomeEmptyViewodel {
+    let title: String
+    let subtitle: String
+}
+
+final class HomeEmptyView: UIView {
+    
+    private let containerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .hpWhite
+        view.layer.cornerRadius = 16
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.hpGray4.cgColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .hpBlack
+        label.font = .bodySemibold
+        label.numberOfLines = 1
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .hpBlack
+        label.font = .captionRegular
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+    func setup(model: HomeEmptyViewodel) {
+        titleLabel.text = model.title
+        subtitleLabel.text = model.subtitle
+    }
+    
+}
+
+private extension HomeEmptyView {
+    
+    func setupViews() {
+        backgroundColor = .hpWhite
+        addSubview(containerView)
+        [titleLabel, subtitleLabel].forEach(containerView.addSubview)
+        
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: topAnchor),
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            titleLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
+            titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10),
+            
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
+            subtitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.leadingOffset),
+            subtitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: Constants.traillingOffset),
+            subtitleLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -20),
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/Views/HomeSeeAllView.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/Views/HomeSeeAllView.swift
@@ -1,0 +1,69 @@
+//
+//  HomeSeeAllView.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/14/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import DesignKit
+
+final class HomeSeeAllView: UIView {
+    
+    private enum Constant {
+        static let title = "모두 보기"
+        static let imageWidth: CGFloat = 15
+        static let imageHeight: CGFloat = imageWidth
+        static let imageName = "chevron.right"
+    }
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = Constant.title
+        label.textColor = .hpGray1
+        label.font = .captionRegular
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let arrowImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.tintColor = .hpGray1
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(systemName: Constant.imageName)?.withRenderingMode(.alwaysTemplate)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+}
+
+private extension HomeSeeAllView {
+    
+    func setupViews() {
+        addSubview(titleLabel)
+        addSubview(arrowImageView)
+        NSLayoutConstraint.activate([
+            arrowImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            arrowImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            arrowImageView.widthAnchor.constraint(equalToConstant: Constant.imageWidth),
+            arrowImageView.heightAnchor.constraint(equalToConstant: Constant.imageHeight),
+            
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: arrowImageView.leadingAnchor)
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/Views/HomeTitleView.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/Views/HomeTitleView.swift
@@ -1,0 +1,76 @@
+//
+//  HomeTitleCell.swift
+//  HomeImplementations
+//
+//  Created by 홍성준 on 11/14/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import DesignKit
+
+struct HomeTitleViewModel {
+    let title: String
+    let isButtonEnabled: Bool
+}
+
+final class HomeTitleView: UIView {
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.textColor = .hpBlack
+        label.font = .largeBold
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var seeAllView: HomeSeeAllView = {
+        let seeAllView = HomeSeeAllView()
+        seeAllView.addTapGesture(target: self, action: #selector(seeAllViewDidTap))
+        seeAllView.translatesAutoresizingMaskIntoConstraints = false
+        return seeAllView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+    func setup(model: HomeTitleViewModel) {
+        titleLabel.text = model.title
+        seeAllView.isHidden = !model.isButtonEnabled
+    }
+    
+}
+
+private extension HomeTitleView {
+    
+    @objc private func seeAllViewDidTap() {
+        
+    }
+    
+}
+
+private extension HomeTitleView {
+    
+    private func setupViews() {
+        addSubview(titleLabel)
+        addSubview(seeAllView)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            
+            seeAllView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            seeAllView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+    
+}


### PR DESCRIPTION
## 🌁 배경
* #62 
* PR이 너무 커질 것 같아서 비어있는 케이스(정보가 없을 때)만 따로 해서 PR로 올립니다

## ✅ 수정 내역
* 추천 장소 section 추가
* 핫플레이스 section 추가
* 팔로잉 section 추가

## 📕 리뷰 노트
* Home이 추천 장소, 핫플레이스, 팔로잉에 대한 리블렛을 가지고 있는 구조
* 즉 1개의 ViewController와 3개의 ViewController가 존재

## 🎇 스크린샷
![Simulator Screenshot - iPhone 15 Pro - 2023-11-15 at 11 51 35](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/fe470105-e767-4456-9504-f637ecf1e576)

