### PR TITLE
스토리 생성 취소 시 Home tab 이동 추가

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
@@ -12,6 +12,7 @@ protocol AppRootRouting: ViewableRouting {
     func attachSignIn()
     func detachSignIn()
     func attachTabs()
+    func routeToHomeTab()
 }
 
 protocol AppRootPresentable: Presentable {
@@ -55,4 +56,7 @@ final class AppRootInteractor: PresentableInteractor<AppRootPresentable>, AppRoo
         router?.attachTabs()
     }
     
+    func newStoryDidTapClose() {
+        router?.routeToHomeTab()
+    }
 }

--- a/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
@@ -25,6 +25,7 @@ protocol AppRootInteractable: Interactable,
 
 protocol AppRootViewControllable: ViewControllable {
     func setViewControllers(_ viewControllers: [ViewControllable])
+    func selectTab(index: Int)
 }
 
 protocol AppRootRouterDependency {
@@ -105,4 +106,9 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
         
         viewController.setViewControllers(viewControllers)
     }
+    
+    func routeToHomeTab() {
+        viewController.selectTab(index: 0)
+    }
+    
 }

--- a/client/Targets/App/Sources/AppRoot/AppRootTabBarController.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootTabBarController.swift
@@ -28,6 +28,14 @@ final class AppRootTabBarController: UITabBarController, AppRootPresentable, App
         super.setViewControllers(viewControllers.map(\.uiviewController), animated: false)
     }
     
+    func selectTab(index: Int) {
+        guard let numberOfTabs = viewControllers?.count,
+              (0..<numberOfTabs) ~= index else {
+            return
+        }
+        selectedIndex = index
+    }
+    
     private func setupTabBar() {
         let appearance: UITabBarAppearance = tabBar.standardAppearance
         appearance.configureWithDefaultBackground()

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorInteractor.swift
@@ -19,6 +19,7 @@ public protocol StoryEditorPresentable: Presentable {
 
 public protocol StoryEditorListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
+    func newStoryDidTapClose()
 }
 
 final class StoryEditorInteractor: PresentableInteractor<StoryEditorPresentable>, StoryEditorInteractable, StoryEditorPresentableListener {
@@ -41,5 +42,9 @@ final class StoryEditorInteractor: PresentableInteractor<StoryEditorPresentable>
     override func willResignActive() {
         super.willResignActive()
         // TODO: Pause any business logic.
+    }
+    
+    func didTapClose() {
+        listener?.newStoryDidTapClose()
     }
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
@@ -12,17 +12,28 @@ import ModernRIBs
 
 import DesignKit
 
-public protocol StoryEditorPresentableListener: AnyObject {}
+public protocol StoryEditorPresentableListener: AnyObject {
+    func didTapClose()
+}
 
 final class StoryEditorViewController: UIViewController, StoryEditorPresentable, StoryEditorViewControllable {
     
     private enum Constant {
-        static let tabBarTitle = "새 스토리"
+        static let navBarTitle = "스토리 생성"
         static let tabBarImage = "plus.circle"
         static let tabBarImageSelected = "plus.circle.fill"
     }
     
     weak var listener: StoryEditorPresentableListener?
+    
+    private lazy var navigationView: NavigationView = {
+        let navigationView = NavigationView()
+        navigationView.setup(model: .init(title: Constant.navBarTitle, leftButtonType: .back, rightButtonTypes: []))
+        navigationView.delegate = self
+        navigationView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return navigationView
+    }()
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -45,12 +56,28 @@ private extension StoryEditorViewController {
     
     func setupViews() {
         view.backgroundColor = .hpWhite
+        [navigationView].forEach(view.addSubview)
+        
+        NSLayoutConstraint.activate([
+            navigationView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationView.heightAnchor.constraint(equalToConstant: Constants.navigationViewHeight),
+        ])
     }
     
     func setupTabBar() {
-        tabBarItem = .init(title: Constant.tabBarTitle,
+        tabBarItem = .init(title: "",
                            image: UIImage(systemName: Constant.tabBarImage)?.withRenderingMode(.alwaysTemplate),
                            selectedImage: UIImage(systemName: Constant.tabBarImageSelected)?.withRenderingMode(.alwaysTemplate))
     }
+    
+}
+
+extension StoryEditorViewController: NavigationViewDelegate {
+    func navigationViewButtonDidTap(_ view: DesignKit.NavigationView, type: DesignKit.NavigationViewButtonType) {
+        listener?.didTapClose()
+    }
+    
     
 }


### PR DESCRIPTION
## 🌁 배경
* #53 

## ✅ 수정 내역
* 스토리 생성 취소 시 Home Tab 이동 추가

## 📕 리뷰 노트
* App Root 수정으로 conflict 방지를 위해 먼저 PR 날립니다

## 🎇 스크린샷
* 
![Simulator Screen Recording - iPhone 15 - 2023-11-15 at 13 39 18](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/82424906-96a6-4dc0-bf28-2a693b1e6a16)

