### PR TITLE
StoryCreator 추가

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
@@ -25,7 +25,7 @@ final class AppRootComponent: Component<AppRootDependency>,
                               SignInDependency,
                               HomeDependency,
                               SearchHomeDependency, 
-                              StoryEditorDependency {
+                              StoryCreatorDependency {    
     
     let authUseCase: AuthUseCaseInterface
     let naverLoginRepository: NaverLoginRepositoryInterface
@@ -44,8 +44,8 @@ final class AppRootComponent: Component<AppRootDependency>,
         SearchHomeBuilder(dependency: self)
     }()
     
-    lazy var storyEditorBuilder: StoryEditorBuildable = {
-        StoryEditorBuilder(dependency: self)
+    lazy var storyCreatorBuilder: StoryCreatorBuildable = {
+        StoryCreatorBuilder(dependency: self)
     }()
     
     override init(dependency: AppRootDependency) {

--- a/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
@@ -56,7 +56,8 @@ final class AppRootInteractor: PresentableInteractor<AppRootPresentable>, AppRoo
         router?.attachTabs()
     }
     
-    func newStoryDidTapClose() {
+    // MARK: - Story Creator
+    func storyCreatorDidComplete() {
         router?.routeToHomeTab()
     }
 }

--- a/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
@@ -12,7 +12,7 @@ protocol AppRootRouting: ViewableRouting {
     func attachSignIn()
     func detachSignIn()
     func attachTabs()
-    func routeToHomeTab()
+    func routeToPreivousTab()
 }
 
 protocol AppRootPresentable: Presentable {
@@ -58,6 +58,7 @@ final class AppRootInteractor: PresentableInteractor<AppRootPresentable>, AppRoo
     
     // MARK: - Story Creator
     func storyCreatorDidComplete() {
-        router?.routeToHomeTab()
+        // TODO: Route to previous tab
+        router?.routeToPreivousTab()
     }
 }

--- a/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
@@ -18,7 +18,7 @@ protocol AppRootInteractable: Interactable,
                               SignInListener,
                               SearchHomeListener,
                               HomeListener, 
-                              StoryEditorListener {
+                              StoryCreatorListener {
     var router: AppRootRouting? { get set }
     var listener: AppRootListener? { get set }
 }
@@ -32,7 +32,7 @@ protocol AppRootRouterDependency {
     var signInBuilder: SignInBuildable { get }
     var homeBuilder: HomeBuildable { get }
     var searchBuilder: SearchHomeBuildable { get }
-    var storyEditorBuilder: StoryEditorBuildable { get }
+    var storyCreatorBuilder: StoryCreatorBuildable { get }
 }
 
 
@@ -47,8 +47,8 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
     private let searchHomeBuilder: SearchHomeBuildable
     private var searchHomeRouter: Routing?
     
-    private let storyEditorBuilder: StoryEditorBuildable
-    private var storyEditorRouter: Routing?
+    private let storyCreatorBuilder: StoryCreatorBuildable
+    private var storyCreatorRouter: Routing?
     
     init(
         interactor: AppRootInteractable,
@@ -58,7 +58,7 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
         self.signInBuilder = dependency.signInBuilder
         self.homeBuilder = dependency.homeBuilder
         self.searchHomeBuilder = dependency.searchBuilder
-        self.storyEditorBuilder = dependency.storyEditorBuilder
+        self.storyCreatorBuilder = dependency.storyCreatorBuilder
         
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
@@ -94,14 +94,14 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
         self.searchHomeRouter = searchHomeRouting
         attachChild(searchHomeRouting)
         
-        let storyEditorRouting = storyEditorBuilder.build(withListener: interactor)
-        self.storyEditorRouter = storyEditorRouting
-        attachChild(storyEditorRouting)
+        let storyCreatorRouting = storyCreatorBuilder.build(withListener: interactor)
+        self.storyCreatorRouter = storyCreatorRouting
+        attachChild(storyCreatorRouting)
         
         let viewControllers = [
             NavigationControllable(viewControllable: homeRouting.viewControllable),
             NavigationControllable(viewControllable: searchHomeRouting.viewControllable),
-            NavigationControllable(viewControllable: storyEditorRouting.viewControllable),
+            NavigationControllable(viewControllable: storyCreatorRouting.viewControllable),
         ]
         
         viewController.setViewControllers(viewControllers)

--- a/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
@@ -25,7 +25,7 @@ protocol AppRootInteractable: Interactable,
 
 protocol AppRootViewControllable: ViewControllable {
     func setViewControllers(_ viewControllers: [ViewControllable])
-    func selectTab(index: Int)
+    func selectPreviousTab()
 }
 
 protocol AppRootRouterDependency {
@@ -107,8 +107,8 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
         viewController.setViewControllers(viewControllers)
     }
     
-    func routeToHomeTab() {
-        viewController.selectTab(index: 0)
+    func routeToPreivousTab() {
+        viewController.selectPreviousTab()
     }
     
 }

--- a/client/Targets/App/Sources/AppRoot/AppRootTabBarController.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootTabBarController.swift
@@ -17,6 +17,7 @@ protocol AppRootPresentableListener: AnyObject {
 final class AppRootTabBarController: UITabBarController, AppRootPresentable, AppRootViewControllable {
 
     weak var listener: AppRootPresentableListener?
+    private var previousTabIndex: Int = 0
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,12 +29,12 @@ final class AppRootTabBarController: UITabBarController, AppRootPresentable, App
         super.setViewControllers(viewControllers.map(\.uiviewController), animated: false)
     }
     
-    func selectTab(index: Int) {
+    func selectPreviousTab() {
         guard let numberOfTabs = viewControllers?.count,
-              (0..<numberOfTabs) ~= index else {
+              (0..<numberOfTabs) ~= previousTabIndex else {
             return
         }
-        selectedIndex = index
+        selectedIndex = previousTabIndex
     }
     
     private func setupTabBar() {
@@ -48,4 +49,8 @@ final class AppRootTabBarController: UITabBarController, AppRootPresentable, App
         tabBar.unselectedItemTintColor = .hpGray2
     }
     
+    override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
+        guard let tabIndex = tabBar.items?.firstIndex(of: item), tabIndex != 2 else { return }
+        previousTabIndex = tabIndex
+    }
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorBuilder.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorBuilder.swift
@@ -1,0 +1,40 @@
+//
+//  StoryCreatorBuilder.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol StoryCreatorDependency: Dependency {
+    // TODO: Declare the set of dependencies required by this RIB, but cannot be
+    // created by this RIB.
+}
+
+final class StoryCreatorComponent: Component<StoryCreatorDependency> {
+
+    // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
+}
+
+// MARK: - Builder
+
+protocol StoryCreatorBuildable: Buildable {
+    func build(withListener listener: StoryCreatorListener) -> StoryCreatorRouting
+}
+
+final class StoryCreatorBuilder: Builder<StoryCreatorDependency>, StoryCreatorBuildable {
+
+    override init(dependency: StoryCreatorDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: StoryCreatorListener) -> StoryCreatorRouting {
+        let component = StoryCreatorComponent(dependency: dependency)
+        let viewController = StoryCreatorViewController()
+        let interactor = StoryCreatorInteractor(presenter: viewController)
+        interactor.listener = listener
+        return StoryCreatorRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorBuilder.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorBuilder.swift
@@ -8,14 +8,15 @@
 
 import ModernRIBs
 
-public protocol StoryCreatorDependency: Dependency {
-    // TODO: Declare the set of dependencies required by this RIB, but cannot be
-    // created by this RIB.
-}
+public protocol StoryCreatorDependency: Dependency {}
 
-final class StoryCreatorComponent: Component<StoryCreatorDependency> {
+final class StoryCreatorComponent: Component<StoryCreatorDependency>,
+                                   StoryCreatorRouterDependency,
+                                   StoryEditorDependency {
 
-    // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
+    lazy var storyEditorBuilder: StoryEditorBuildable = {
+        StoryEditorBuilder(dependency: self)
+    }()
 }
 
 // MARK: - Builder
@@ -35,6 +36,10 @@ public final class StoryCreatorBuilder: Builder<StoryCreatorDependency>, StoryCr
         let viewController = StoryCreatorViewController()
         let interactor = StoryCreatorInteractor(presenter: viewController)
         interactor.listener = listener
-        return StoryCreatorRouter(interactor: interactor, viewController: viewController)
+        
+        return StoryCreatorRouter(interactor: interactor,
+                                  viewController: viewController,
+                                  dependency: component)
     }
+    
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorBuilder.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorBuilder.swift
@@ -8,7 +8,7 @@
 
 import ModernRIBs
 
-protocol StoryCreatorDependency: Dependency {
+public protocol StoryCreatorDependency: Dependency {
     // TODO: Declare the set of dependencies required by this RIB, but cannot be
     // created by this RIB.
 }
@@ -20,17 +20,17 @@ final class StoryCreatorComponent: Component<StoryCreatorDependency> {
 
 // MARK: - Builder
 
-protocol StoryCreatorBuildable: Buildable {
+public protocol StoryCreatorBuildable: Buildable {
     func build(withListener listener: StoryCreatorListener) -> StoryCreatorRouting
 }
 
-final class StoryCreatorBuilder: Builder<StoryCreatorDependency>, StoryCreatorBuildable {
+public final class StoryCreatorBuilder: Builder<StoryCreatorDependency>, StoryCreatorBuildable {
 
-    override init(dependency: StoryCreatorDependency) {
+    public override init(dependency: StoryCreatorDependency) {
         super.init(dependency: dependency)
     }
 
-    func build(withListener listener: StoryCreatorListener) -> StoryCreatorRouting {
+    public func build(withListener listener: StoryCreatorListener) -> StoryCreatorRouting {
         let component = StoryCreatorComponent(dependency: dependency)
         let viewController = StoryCreatorViewController()
         let interactor = StoryCreatorInteractor(presenter: viewController)

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorInteractor.swift
@@ -9,20 +9,20 @@
 import ModernRIBs
 
 public protocol StoryCreatorRouting: ViewableRouting {
-    // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
+    func attachStoryEditor()
+    func detachStoryEditor()
 }
 
 public protocol StoryCreatorPresentable: Presentable {
     var listener: StoryCreatorPresentableListener? { get set }
-    // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
 public protocol StoryCreatorListener: AnyObject {
-    // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
+    func storyCreatorDidComplete()
 }
 
 final class StoryCreatorInteractor: PresentableInteractor<StoryCreatorPresentable>, StoryCreatorInteractable, StoryCreatorPresentableListener {
-
+    
     weak var router: StoryCreatorRouting?
     weak var listener: StoryCreatorListener?
 
@@ -35,11 +35,20 @@ final class StoryCreatorInteractor: PresentableInteractor<StoryCreatorPresentabl
 
     override func didBecomeActive() {
         super.didBecomeActive()
-        // TODO: Implement business logic here.
     }
 
     override func willResignActive() {
         super.willResignActive()
-        // TODO: Pause any business logic.
     }
+    
+    func viewDidAppear() {
+        router?.attachStoryEditor()
+    }
+    
+    func storyEditorDidTapClose() {
+        router?.detachStoryEditor()
+        listener?.storyCreatorDidComplete()
+    }
+    
+
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorInteractor.swift
@@ -8,16 +8,16 @@
 
 import ModernRIBs
 
-protocol StoryCreatorRouting: ViewableRouting {
+public protocol StoryCreatorRouting: ViewableRouting {
     // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
 }
 
-protocol StoryCreatorPresentable: Presentable {
+public protocol StoryCreatorPresentable: Presentable {
     var listener: StoryCreatorPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol StoryCreatorListener: AnyObject {
+public protocol StoryCreatorListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorInteractor.swift
@@ -1,0 +1,45 @@
+//
+//  StoryCreatorInteractor.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol StoryCreatorRouting: ViewableRouting {
+    // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
+}
+
+protocol StoryCreatorPresentable: Presentable {
+    var listener: StoryCreatorPresentableListener? { get set }
+    // TODO: Declare methods the interactor can invoke the presenter to present data.
+}
+
+protocol StoryCreatorListener: AnyObject {
+    // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
+}
+
+final class StoryCreatorInteractor: PresentableInteractor<StoryCreatorPresentable>, StoryCreatorInteractable, StoryCreatorPresentableListener {
+
+    weak var router: StoryCreatorRouting?
+    weak var listener: StoryCreatorListener?
+
+    // TODO: Add additional dependencies to constructor. Do not perform any logic
+    // in constructor.
+    override init(presenter: StoryCreatorPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+        // TODO: Implement business logic here.
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+        // TODO: Pause any business logic.
+    }
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorRouter.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorRouter.swift
@@ -1,0 +1,27 @@
+//
+//  StoryCreatorRouter.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol StoryCreatorInteractable: Interactable {
+    var router: StoryCreatorRouting? { get set }
+    var listener: StoryCreatorListener? { get set }
+}
+
+protocol StoryCreatorViewControllable: ViewControllable {
+    // TODO: Declare methods the router invokes to manipulate the view hierarchy.
+}
+
+final class StoryCreatorRouter: ViewableRouter<StoryCreatorInteractable, StoryCreatorViewControllable>, StoryCreatorRouting {
+
+    // TODO: Constructor inject child builder protocols to allow building children.
+    override init(interactor: StoryCreatorInteractable, viewController: StoryCreatorViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorRouter.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorRouter.swift
@@ -8,12 +8,12 @@
 
 import ModernRIBs
 
-protocol StoryCreatorInteractable: Interactable {
+public protocol StoryCreatorInteractable: Interactable {
     var router: StoryCreatorRouting? { get set }
     var listener: StoryCreatorListener? { get set }
 }
 
-protocol StoryCreatorViewControllable: ViewControllable {
+public protocol StoryCreatorViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorViewController.swift
@@ -1,0 +1,21 @@
+//
+//  StoryCreatorViewController.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+import UIKit
+
+protocol StoryCreatorPresentableListener: AnyObject {
+    // TODO: Declare properties and methods that the view controller can invoke to perform
+    // business logic, such as signIn(). This protocol is implemented by the corresponding
+    // interactor class.
+}
+
+final class StoryCreatorViewController: UIViewController, StoryCreatorPresentable, StoryCreatorViewControllable {
+
+    weak var listener: StoryCreatorPresentableListener?
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorViewController.swift
@@ -6,10 +6,13 @@
 //  Copyright © 2023 codesquad. All rights reserved.
 //
 
-import ModernRIBs
 import UIKit
 
-protocol StoryCreatorPresentableListener: AnyObject {
+import ModernRIBs
+
+import DesignKit
+
+public protocol StoryCreatorPresentableListener: AnyObject {
     // TODO: Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor class.
@@ -17,5 +20,45 @@ protocol StoryCreatorPresentableListener: AnyObject {
 
 final class StoryCreatorViewController: UIViewController, StoryCreatorPresentable, StoryCreatorViewControllable {
 
+    private enum Constant {
+        static let tabBarImage = "plus.circle"
+        static let tabBarImageSelected = "plus.circle.fill"
+    }
+    
     weak var listener: StoryCreatorPresentableListener?
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        setupTabBar()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupTabBar()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViews()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        
+    }
+    
 }
+
+private extension StoryCreatorViewController {
+    
+    func setupViews() {
+        view.backgroundColor = .hpWhite
+    }
+    
+    func setupTabBar() {
+        tabBarItem = .init(title: "",
+                           image: UIImage(systemName: Constant.tabBarImage)?.withRenderingMode(.alwaysTemplate),
+                           selectedImage: UIImage(systemName: Constant.tabBarImageSelected)?.withRenderingMode(.alwaysTemplate))
+    }
+    
+}
+

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorViewController.swift
@@ -13,9 +13,7 @@ import ModernRIBs
 import DesignKit
 
 public protocol StoryCreatorPresentableListener: AnyObject {
-    // TODO: Declare properties and methods that the view controller can invoke to perform
-    // business logic, such as signIn(). This protocol is implemented by the corresponding
-    // interactor class.
+    func viewDidAppear()
 }
 
 final class StoryCreatorViewController: UIViewController, StoryCreatorPresentable, StoryCreatorViewControllable {
@@ -43,7 +41,7 @@ final class StoryCreatorViewController: UIViewController, StoryCreatorPresentabl
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        
+        listener?.viewDidAppear()
     }
     
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorInteractor.swift
@@ -19,7 +19,7 @@ public protocol StoryEditorPresentable: Presentable {
 
 public protocol StoryEditorListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
-    func newStoryDidTapClose()
+    func storyEditorDidTapClose()
 }
 
 final class StoryEditorInteractor: PresentableInteractor<StoryEditorPresentable>, StoryEditorInteractable, StoryEditorPresentableListener {
@@ -45,6 +45,6 @@ final class StoryEditorInteractor: PresentableInteractor<StoryEditorPresentable>
     }
     
     func didTapClose() {
-        listener?.newStoryDidTapClose()
+        listener?.storyEditorDidTapClose()
     }
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
@@ -37,12 +37,10 @@ final class StoryEditorViewController: UIViewController, StoryEditorPresentable,
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        setupTabBar()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        setupTabBar()
     }
     
     override func viewDidLoad() {
@@ -66,18 +64,12 @@ private extension StoryEditorViewController {
         ])
     }
     
-    func setupTabBar() {
-        tabBarItem = .init(title: "",
-                           image: UIImage(systemName: Constant.tabBarImage)?.withRenderingMode(.alwaysTemplate),
-                           selectedImage: UIImage(systemName: Constant.tabBarImageSelected)?.withRenderingMode(.alwaysTemplate))
-    }
-    
 }
 
 extension StoryEditorViewController: NavigationViewDelegate {
+    
     func navigationViewButtonDidTap(_ view: DesignKit.NavigationView, type: DesignKit.NavigationViewButtonType) {
         listener?.didTapClose()
     }
-    
-    
+
 }


### PR DESCRIPTION
## 🌁 배경
* #53 

## ✅ 수정 내역
* 스토리 생성 리블렛 추가
* TabBar에 연결한 StoryEditor를 StoryCreator로 교체하고 StoryCreator가 Editor를 attach하도록 교체
* 스토리 생성 취소 시 이전 사용한 탭으로 이동하도록 교체

## 📕 리뷰 노트
* 직전 PR이 거의 의미가 없었네요... 죄송합니다. 
* Editor view 구현 전에 끊어서 PR 날립니다.

## 🎇 스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-11-15 at 15 59 18](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/cb9911cd-07b4-41ad-a32f-df28bac63647)

