### PR TITLE
custom 에러 추가(Invalid 토큰 검사), Entity 연관 관계 수정

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import { User } from 'src/entities/user.entity';
 import { idDuplicatedException } from 'src/exception/cuntom.exception/id.duplicate.exception';
 import { profileImage } from 'src/entities/profileImage.entity';
 import { ImageService } from '../image/image.service';
+import { invalidTokenException } from 'src/exception/cuntom.exception/token.invalid.exception';
 
 @Injectable()
 export class AuthService {
@@ -53,14 +54,17 @@ export class AuthService {
   async getId(token: string): Promise<string> {
     const header = 'Bearer ' + token;
     const api_url = 'https://openapi.naver.com/v1/nid/me';
-
-    const response = await fetch(api_url, {
-      method: 'GET',
-      headers: {
-        Authorization: header,
-      },
-    });
-    const responseJson = await response.json();
-    return responseJson.response.id;
+    try {
+      const response = await fetch(api_url, {
+        method: 'GET',
+        headers: {
+          Authorization: header,
+        },
+      });
+      const responseJson = await response.json();
+      return responseJson.response.id;
+    } catch (error) {
+      throw new invalidTokenException();
+    }
   }
 }

--- a/server/src/entities/story.entity.ts
+++ b/server/src/entities/story.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, ManyToMany, JoinTable } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, ManyToMany, JoinTable, OneToMany } from 'typeorm';
 import { User } from './user.entity';
 import { Category } from './category.entity';
+import { StoryImage } from './storyImage.entity';
 
 @Entity()
 export class Story {
@@ -16,8 +17,8 @@ export class Story {
   @Column('text')
   content: string;
 
-  @Column()
-  storyImageURL: string;
+  @OneToMany(() => StoryImage, (storyImage) => storyImage.story, { cascade: true })
+  storyImages: Promise<StoryImage[]>;
 
   @Column()
   likeCount: number;

--- a/server/src/entities/storyImage.entity.ts
+++ b/server/src/entities/storyImage.entity.ts
@@ -2,7 +2,7 @@ import { Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn } from 'ty
 import { Story } from './story.entity';
 
 @Entity()
-export class storyImage {
+export class StoryImage {
   @PrimaryGeneratedColumn()
   imageId: number;
 

--- a/server/src/exception/cuntom.exception/token.invalid.exception.ts
+++ b/server/src/exception/cuntom.exception/token.invalid.exception.ts
@@ -1,0 +1,7 @@
+import { HttpException } from '@nestjs/common';
+
+export class invalidTokenException extends HttpException {
+  constructor() {
+    super('Invalid Token', 498);
+  }
+}

--- a/server/src/search/search.repository.ts
+++ b/server/src/search/search.repository.ts
@@ -10,7 +10,6 @@ export class SearchRepository {
     private searchRepository: Repository<SearchHistory>,
   ) {}
   async save(searchText: string) {
-    console.log(searchText);
     const existingHistory = await this.searchRepository.findOne({ where: { content: searchText } });
     if (existingHistory) {
       existingHistory.count += 1;

--- a/server/src/story/story.service.ts
+++ b/server/src/story/story.service.ts
@@ -5,6 +5,7 @@ import { StoryDetailViewData } from './type/story.detail.view.data';
 import { userDataInStoryView } from './type/story.user.data';
 import { UserRepository } from './../user/user.repository';
 import { ImageService } from '../image/image.service';
+import { StoryImage } from 'src/entities/storyImage.entity';
 
 @Injectable()
 export class StoryService {
@@ -19,7 +20,12 @@ export class StoryService {
     const story = new Story();
     story.title = title;
     story.content = content;
-    story.storyImageURL = JSON.stringify(savedImagePaths);
+    const storyImageArr = await story.storyImages;
+    savedImagePaths.forEach((path) => {
+      const storyImageObj = new StoryImage();
+      storyImageObj.imageUrl = path;
+      storyImageArr.push(storyImageObj);
+    });
     story.createAt = new Date();
     story.likeCount = 0;
 


### PR DESCRIPTION
## 🌁 배경
* close #124 

## ✅ 수정 내역
- Invalid 토큰을 이용한 로그인, 회원가입 시도 시 498 Status code와 메세지를 리턴합니다.
- Story Entity 연관관계 수정


## 🎇 스크린샷
![image](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/51906365/5b824a3f-9731-407d-9a21-eb22235a5666)
