### PR TITLE
Story Editor View 추가

### DIFF
--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/AttributeField.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/AttributeField.swift
@@ -1,0 +1,23 @@
+//
+//  AttributeField.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/16/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+
+class AttributeField: UITableView {
+
+    override var contentSize:CGSize {
+        didSet {
+            invalidateIntrinsicContentSize()
+        }
+    }
+        
+    override var intrinsicContentSize: CGSize {
+        layoutIfNeeded()
+        return CGSize(width: UIView.noIntrinsicMetric, height: contentSize.height)
+    }
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/AttributeTableViewCell.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/AttributeTableViewCell.swift
@@ -1,0 +1,192 @@
+//
+//  AttributeTableViewCell.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/16/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+
+enum AttributeType {
+    case category(String)
+    case location(String)
+    case date(Date)
+    case badge(String)
+}
+
+extension AttributeType {
+    var title: String {
+        switch self {
+        case .category(_): return "카테고리"
+        case .location(_): return "위치"
+        case .date(_): return "날짜"
+        case .badge(_): return "칭호"
+        }
+    }
+    
+    var items: [String] {
+        switch self {
+        case .category(_): return ["없음", "여행", "맛집", "카페", "디저트", "데이트"]
+        case .badge(_): return ["없음", "뚜벅이", "뉴비", "카페인 중독자", "맛집 탐험가"]
+        case .date(_), .location(_): return ["없음"]
+        }
+    }
+}
+
+class AttributeTableViewCell: UITableViewCell {
+
+    private var attributeType: AttributeType?
+    private let dateFormat: Date.FormatStyle = Date.FormatStyle()
+                                                    .year(.defaultDigits)
+                                                    .month(.abbreviated)
+                                                    .day(.twoDigits)
+                                                    .hour(.defaultDigits(amPM: .abbreviated))
+                                                    .minute(.twoDigits)
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyBold
+        label.textColor = .hpBlack
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var valueLabel: UITextField = {
+        let textField = UITextField()
+        textField.text = "없음"
+        textField.font = .smallRegular
+        textField.textColor = .hpGray1
+        textField.tintColor = .clear
+
+        
+        
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        return textField
+    }()
+    
+    private let accessaryImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .init(systemName: "chevron.right")
+        imageView.tintColor = .hpBlack
+        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        //setupViews()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+        selectionStyle = .none
+    }
+    
+    func setup(type: AttributeType) {
+        setupViews()
+        attributeType = type
+        titleLabel.text = type.title
+        setupValue(for: type)
+        setupPicker(for: type)
+    }
+
+    func presentPicker() {
+        valueLabel.becomeFirstResponder()
+    }
+}
+
+private extension AttributeTableViewCell {
+    
+    func setupViews() {
+        [titleLabel, valueLabel, accessaryImage].forEach(contentView.addSubview)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            
+            valueLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            
+            accessaryImage.leadingAnchor.constraint(equalTo: valueLabel.trailingAnchor, constant: 5),
+            accessaryImage.trailingAnchor.constraint(equalTo: trailingAnchor),
+            accessaryImage.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+    
+    func setupValue(for type: AttributeType) {
+        switch type {
+        case .category(let value), .location(let value), .badge(let value):
+            valueLabel.text = value
+        case .date(_):
+            let currentTime = Date.now
+            attributeType = .date(currentTime)
+            valueLabel.text = currentTime.formatted(dateFormat)
+        }
+    }
+    
+    func setupPicker(for type: AttributeType) {
+        switch type {
+        case .category(_), .badge(_), .location(_):
+            let pickerView = UIPickerView()
+            pickerView.delegate = self
+            pickerView.dataSource = self
+            pickerView.backgroundColor = .hpWhite
+            valueLabel.inputView = pickerView
+            
+        case .date(_):
+            let datePicker = UIDatePicker()
+            datePicker.datePickerMode = .dateAndTime
+            datePicker.preferredDatePickerStyle = .wheels
+            datePicker.backgroundColor = .hpWhite
+            datePicker.addTarget(self, action: #selector(datePickerValueDidChange), for: .valueChanged)
+            
+            valueLabel.inputView = datePicker
+        }
+        
+        let toolBar = UIToolbar()
+        toolBar.sizeToFit()
+        let button = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(dismissPicker))
+        toolBar.setItems([button], animated: true)
+        toolBar.isUserInteractionEnabled = true
+        valueLabel.inputAccessoryView = toolBar
+    }
+    
+}
+
+private extension AttributeTableViewCell {
+    
+    @objc func dismissPicker() {
+        valueLabel.resignFirstResponder()
+    }
+    
+    @objc func datePickerValueDidChange(_ datePicker: UIDatePicker) {
+        valueLabel.text = datePicker.date.formatted(dateFormat)
+    }
+    
+}
+
+extension AttributeTableViewCell: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        guard let value = attributeType?.items[row] else { return }
+        
+        valueLabel.text = value
+    }
+}
+
+extension AttributeTableViewCell: UIPickerViewDataSource {
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return attributeType?.items.count ?? 0
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return attributeType?.items[row]
+    }
+    
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/DescriptionField.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/DescriptionField.swift
@@ -1,0 +1,71 @@
+//
+//  DescriptionField.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/16/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+
+final class DescriptionField: UIView {
+
+    var title: String? {
+        textField.text
+    }
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.text = "설명"
+        label.font = .bodyBold
+        label.textColor = .hpBlack
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let textField: UITextView = {
+        let textField = UITextView()
+        textField.isEditable = true
+        textField.font = .captionRegular
+        textField.textAlignment = .natural
+        textField.isScrollEnabled = false
+        textField.isUserInteractionEnabled = true
+        textField.textContainerInset = .init(top: 10, left: 20, bottom: 10, right: 20)
+        
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        return textField
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+}
+
+private extension DescriptionField {
+    func setupViews() {
+        [label, textField].forEach(addSubview)
+
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: topAnchor),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor),
+            
+            textField.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 10),
+            textField.leadingAnchor.constraint(equalTo: leadingAnchor),
+            textField.trailingAnchor.constraint(equalTo: trailingAnchor),
+            textField.bottomAnchor.constraint(equalTo: bottomAnchor),
+            textField.heightAnchor.constraint(greaterThanOrEqualToConstant: 125)
+        ])
+        
+        textField.layer.borderWidth = 1
+        textField.layer.borderColor = UIColor.hpGray4.cgColor
+        textField.layer.cornerRadius = 16
+        
+    }
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/DescriptionField.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/DescriptionField.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+import DesignKit
+
 final class DescriptionField: UIView {
 
     var title: String? {
@@ -49,6 +51,7 @@ final class DescriptionField: UIView {
 }
 
 private extension DescriptionField {
+    
     func setupViews() {
         [label, textField].forEach(addSubview)
 
@@ -65,7 +68,7 @@ private extension DescriptionField {
         
         textField.layer.borderWidth = 1
         textField.layer.borderColor = UIColor.hpGray4.cgColor
-        textField.layer.cornerRadius = 16
-        
+        textField.layer.cornerRadius = Constants.cornerRadiusMedium
     }
+    
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageField.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageField.swift
@@ -1,0 +1,118 @@
+//
+//  ImageField.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import PhotosUI
+
+final class ImageField: UIView {
+    
+    weak var presenterDelegate: ImageSelectorPickerPresenterDelegate? {
+        didSet {
+            setPresenter()
+        }
+    }
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.text = "사진"
+        label.font = .bodyBold
+        label.textColor = .hpBlack
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+}
+
+private extension ImageField {
+    func setupViews() {
+        [label, scrollView].forEach(addSubview)
+        scrollView.addSubview(stackView)
+        addImageSelector()
+        
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: topAnchor),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor),
+            
+            scrollView.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 10),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            scrollView.heightAnchor.constraint(equalTo: stackView.heightAnchor),
+            
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
+        ])
+    }
+    
+    func addImageSelector() {
+        guard stackView.arrangedSubviews.count < 5 else { return }
+        let imageSelector = ImageSelector()
+        imageSelector.delegate = self
+        imageSelector.presenterDelegate = presenterDelegate
+        
+        imageSelector.widthAnchor.constraint(equalToConstant: 74).isActive = true
+        imageSelector.heightAnchor.constraint(equalToConstant: 110).isActive = true
+        stackView.addArrangedSubview(imageSelector)
+    }
+    
+    func setPresenter() {
+        stackView.arrangedSubviews.forEach { view in
+            guard let view = view as? ImageSelector else { return }
+            view.presenterDelegate = presenterDelegate
+        }
+    }
+}
+
+extension ImageField: ImageSelectorDelegate {
+    
+    func imageDidAdd() {
+        addImageSelector()
+    }
+    
+    func imageDidRemove(from selector: ImageSelector) {
+        selector.removeFromSuperview()
+        
+        if let selector = stackView.arrangedSubviews.last as? ImageSelector,
+                selector.isSelected {
+            addImageSelector()
+        }
+    }
+    
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
@@ -1,0 +1,149 @@
+//
+//  ImageSelector.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import PhotosUI
+
+protocol ImageSelectorDelegate: AnyObject {
+    func imageDidAdd()
+    func imageDidRemove(from selector: ImageSelector)
+}
+
+protocol ImageSelectorPickerPresenterDelegate: AnyObject {
+    func addImageDidTap(with picker: PHPickerViewController)
+}
+
+final class ImageSelector: UIView {
+
+    enum Constant {
+        static let transparentBlack: UIColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)
+    }
+    weak var delegate: ImageSelectorDelegate?
+    weak var presenterDelegate: ImageSelectorPickerPresenterDelegate?
+    
+    var isSelected: Bool {
+        imageView.image != nil
+    }
+    
+    private lazy var plusImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .init(systemName: "plus.circle.fill")
+        imageView.contentMode = .scaleAspectFill
+        imageView.tintColor = .hpBlack
+        imageView.addTapGesture(target: self, action: #selector(addImageDidTap))
+        imageView.isUserInteractionEnabled = true
+        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private lazy var xImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .init(systemName: "x.circle.fill")
+        imageView.contentMode = .scaleAspectFill
+        imageView.tintColor = Constant.transparentBlack
+        imageView.addTapGesture(target: self, action: #selector(removeImageDidTap))
+        imageView.isUserInteractionEnabled = true
+        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleToFill
+        imageView.clipsToBounds = true
+        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+}
+
+private extension ImageSelector {
+    func setupViews() {
+        [imageView, plusImageView].forEach(addSubview)
+        
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        
+        setupPlusImageView()
+        layer.borderColor = UIColor.hpGray4.cgColor
+        layer.borderWidth = 1
+    }
+    
+    private func setupPlusImageView() {
+        NSLayoutConstraint.activate([
+            plusImageView.widthAnchor.constraint(equalToConstant: 25),
+            plusImageView.heightAnchor.constraint(equalToConstant: 25),
+            plusImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            plusImageView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+    
+    private func setupXImageView() {
+        NSLayoutConstraint.activate([
+            xImageView.widthAnchor.constraint(equalToConstant: 14),
+            xImageView.heightAnchor.constraint(equalToConstant: 14),
+            xImageView.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            xImageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5)
+        ])
+    }
+    
+    @objc func addImageDidTap() {
+        var configuration = PHPickerConfiguration(photoLibrary: .shared())
+        configuration.selectionLimit = 1
+        
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = self
+        presenterDelegate?.addImageDidTap(with: picker)
+    }
+    
+    @objc func removeImageDidTap() {
+        delegate?.imageDidRemove(from: self)
+    }
+}
+
+extension ImageSelector: PHPickerViewControllerDelegate {
+    
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+        
+        guard let itemProvider = results.first?.itemProvider,
+              itemProvider.canLoadObject(ofClass: UIImage.self)
+        else {
+            // TODO: Handle empty results or item provider not being able load UIImage
+            return
+        }
+        
+        itemProvider.loadObject(ofClass: UIImage.self) { image, _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let image = image as? UIImage, let xImageView = self?.xImageView else { return }
+                self?.imageView.image = image
+                self?.plusImageView.removeFromSuperview()
+                self?.addSubview(xImageView)
+                self?.setupXImageView()
+                self?.delegate?.imageDidAdd()
+            }
+        }
+    }
+    
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TextFieldWithPadding.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TextFieldWithPadding.swift
@@ -1,0 +1,28 @@
+//
+//  TextFieldWithPadding.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+
+class TextFieldWithPadding: UITextField {
+    var textPadding = UIEdgeInsets(
+        top: 10,
+        left: 20,
+        bottom: 10,
+        right: 20
+    )
+
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        let rect = super.textRect(forBounds: bounds)
+        return rect.inset(by: textPadding)
+    }
+
+    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        let rect = super.editingRect(forBounds: bounds)
+        return rect.inset(by: textPadding)
+    }
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TextFieldWithPadding.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TextFieldWithPadding.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class TextFieldWithPadding: UITextField {
+final class TextFieldWithPadding: UITextField {
     var textPadding = UIEdgeInsets(
         top: 10,
         left: 20,

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TitleField.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TitleField.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class TitleField: UIView {
+final class TitleField: UIView {
 
     var title: String? {
         textField.text

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TitleField.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TitleField.swift
@@ -1,0 +1,65 @@
+//
+//  TitleField.swift
+//  StoryImplementations
+//
+//  Created by jungmin lim on 11/15/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+
+class TitleField: UIView {
+
+    var title: String? {
+        textField.text
+    }
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.text = "제목"
+        label.font = .bodyBold
+        label.textColor = .hpBlack
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let textField: TextFieldWithPadding = {
+        let textField = TextFieldWithPadding()
+        textField.placeholder = "제목을 입력하세요"
+        
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        return textField
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+}
+
+private extension TitleField {
+    func setupViews() {
+        [label, textField].forEach(addSubview)
+
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: topAnchor),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor),
+            
+            textField.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 10),
+            textField.leadingAnchor.constraint(equalTo: leadingAnchor),
+            textField.trailingAnchor.constraint(equalTo: trailingAnchor),
+            textField.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        
+        textField.layer.borderWidth = 1
+        textField.layer.borderColor = UIColor.hpGray4.cgColor
+        textField.layer.cornerRadius = 16
+        
+    }
+}

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TitleField.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/TitleField.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+import DesignKit
+
 final class TitleField: UIView {
 
     var title: String? {
@@ -44,6 +46,7 @@ final class TitleField: UIView {
 }
 
 private extension TitleField {
+    
     func setupViews() {
         [label, textField].forEach(addSubview)
 
@@ -59,7 +62,7 @@ private extension TitleField {
         
         textField.layer.borderWidth = 1
         textField.layer.borderColor = UIColor.hpGray4.cgColor
-        textField.layer.cornerRadius = 16
-        
+        textField.layer.cornerRadius = Constants.cornerRadiusMedium
     }
+    
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import PhotosUI
 
 import ModernRIBs
 
@@ -62,6 +63,14 @@ final class StoryEditorViewController: UIViewController, StoryEditorPresentable,
         return titleField
     }()
     
+    private lazy var imageField: ImageField = {
+        let imageField = ImageField()
+        imageField.presenterDelegate = self
+        
+        imageField.translatesAutoresizingMaskIntoConstraints = false
+        return imageField
+    }()
+    
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
@@ -83,7 +92,7 @@ private extension StoryEditorViewController {
         view.backgroundColor = .hpWhite
         [navigationView, scrollView].forEach(view.addSubview)
         scrollView.addSubview(stackView)
-        [titleField].forEach(stackView.addArrangedSubview)
+        [titleField, imageField].forEach(stackView.addArrangedSubview)
         NSLayoutConstraint.activate([
             navigationView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             navigationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -109,6 +118,14 @@ extension StoryEditorViewController: NavigationViewDelegate {
     
     func navigationViewButtonDidTap(_ view: DesignKit.NavigationView, type: DesignKit.NavigationViewButtonType) {
         listener?.didTapClose()
+    }
+
+}
+
+extension StoryEditorViewController: ImageSelectorPickerPresenterDelegate {
+    
+    func addImageDidTap(with picker: PHPickerViewController) {
+        present(picker, animated: true)
     }
 
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
@@ -13,6 +13,11 @@ import ModernRIBs
 
 import DesignKit
 
+struct AttributeModel {
+    let title: String
+    var value: String
+}
+
 public protocol StoryEditorPresentableListener: AnyObject {
     func didTapClose()
 }
@@ -78,6 +83,33 @@ final class StoryEditorViewController: UIViewController, StoryEditorPresentable,
         return descriptionField
     }()
     
+    private let saveButton: ActionButton = {
+        let button = ActionButton()
+        button.setTitle("저장하기", for: .normal)
+        
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private var attributes: [AttributeModel] = [.init(title: "카테고리", value: "없음"),
+                                                .init(title: "위치", value: "없음"),
+                                                .init(title: "날짜", value: "없음"),
+                                                .init(title: "칭호", value: "카페인 중독자")]
+    
+    private lazy var attributeField: AttributeField = {
+        let tableView = AttributeField()
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self)
+        tableView.isScrollEnabled = false
+        tableView.allowsSelection = false
+        tableView.rowHeight = 50
+
+        tableView.backgroundColor = .black
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        return tableView
+    }()
+    
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
@@ -99,7 +131,7 @@ private extension StoryEditorViewController {
         view.backgroundColor = .hpWhite
         [navigationView, scrollView].forEach(view.addSubview)
         scrollView.addSubview(stackView)
-        [titleField, imageField, descriptionField].forEach(stackView.addArrangedSubview)
+        [titleField, imageField, descriptionField, attributeField, saveButton].forEach(stackView.addArrangedSubview)
         NSLayoutConstraint.activate([
             navigationView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             navigationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -113,10 +145,14 @@ private extension StoryEditorViewController {
             scrollView.widthAnchor.constraint(equalTo: stackView.widthAnchor, multiplier: 1, constant: Constant.scrollViewInset * 2),
             
             stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            
+            saveButton.heightAnchor.constraint(equalToConstant: 50)
         ])
         
         scrollView.contentInset = .init(top: 40, left: Constant.scrollViewInset, bottom: 0, right: Constant.scrollViewInset)
+        
+        saveButton.layer.cornerRadius = 16
     }
     
 }
@@ -135,4 +171,39 @@ extension StoryEditorViewController: ImageSelectorPickerPresenterDelegate {
         present(picker, animated: true)
     }
 
+}
+
+extension StoryEditorViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    }
+    
+}
+
+extension StoryEditorViewController: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return attributes.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeue(UITableViewCell.self, for: indexPath)
+        
+        var config = cell.defaultContentConfiguration()
+        
+        config.text = attributes[indexPath.row].title
+        config.textProperties.font = .bodyBold
+        config.textProperties.color = .hpBlack
+        
+        config.secondaryText = attributes[indexPath.row].value
+        config.secondaryTextProperties.font = .smallRegular
+        config.secondaryTextProperties.color = .hpGray1
+        config.prefersSideBySideTextAndSecondaryText = true
+        
+        cell.contentConfiguration = config
+        cell.accessoryType = .disclosureIndicator
+        
+        return cell
+    }
+    
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
@@ -20,8 +20,8 @@ final class StoryEditorViewController: UIViewController, StoryEditorPresentable,
     
     private enum Constant {
         static let navBarTitle = "스토리 생성"
-        static let tabBarImage = "plus.circle"
-        static let tabBarImageSelected = "plus.circle.fill"
+        static let scrollViewInset: CGFloat = 20
+        static let stackViewSpacing: CGFloat = 30
     }
     
     weak var listener: StoryEditorPresentableListener?
@@ -33,6 +33,33 @@ final class StoryEditorViewController: UIViewController, StoryEditorPresentable,
         navigationView.translatesAutoresizingMaskIntoConstraints = false
         
         return navigationView
+    }()
+    
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = true
+        scrollView.showsHorizontalScrollIndicator = false
+        
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = Constant.stackViewSpacing
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private lazy var titleField: TitleField = {
+        let titleField = TitleField()
+        
+        titleField.translatesAutoresizingMaskIntoConstraints = false
+        return titleField
     }()
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -54,14 +81,26 @@ private extension StoryEditorViewController {
     
     func setupViews() {
         view.backgroundColor = .hpWhite
-        [navigationView].forEach(view.addSubview)
-        
+        [navigationView, scrollView].forEach(view.addSubview)
+        scrollView.addSubview(stackView)
+        [titleField].forEach(stackView.addArrangedSubview)
         NSLayoutConstraint.activate([
             navigationView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             navigationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             navigationView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             navigationView.heightAnchor.constraint(equalToConstant: Constants.navigationViewHeight),
+            
+            scrollView.topAnchor.constraint(equalTo: navigationView.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            scrollView.widthAnchor.constraint(equalTo: stackView.widthAnchor, multiplier: 1, constant: Constant.scrollViewInset * 2),
+            
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
         ])
+        
+        scrollView.contentInset = .init(top: 40, left: Constant.scrollViewInset, bottom: 0, right: Constant.scrollViewInset)
     }
     
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
@@ -71,6 +71,13 @@ final class StoryEditorViewController: UIViewController, StoryEditorPresentable,
         return imageField
     }()
     
+    private let descriptionField: DescriptionField = {
+        let descriptionField = DescriptionField()
+        
+        descriptionField.translatesAutoresizingMaskIntoConstraints = false
+        return descriptionField
+    }()
+    
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
@@ -92,7 +99,7 @@ private extension StoryEditorViewController {
         view.backgroundColor = .hpWhite
         [navigationView, scrollView].forEach(view.addSubview)
         scrollView.addSubview(stackView)
-        [titleField, imageField].forEach(stackView.addArrangedSubview)
+        [titleField, imageField, descriptionField].forEach(stackView.addArrangedSubview)
         NSLayoutConstraint.activate([
             navigationView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             navigationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),


### PR DESCRIPTION
## 🌁 배경
* #53 

## ✅ 수정 내역
* 스토리 에디터에 필요한 기본 view를 추가했습니다.
* (수정) `cornerRadius`를 `DesignKit`의 `Constants`를 사용하도록 변경했습니다
* (수정) `TableViewCell`의 `ContetConfiguration`을 custom cell로 변경했습니다
* (수정)`UIPickerView`와 `UIDatePicker`를 `AttributeTableViewCell` 내부의 `valueLabel`의 `inputView`로 추가했습니다.

## 📕 리뷰 노트
* 위치 정보는 추가로 작업이 필요합니다.

## 🎇 스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-11-16 at 23 13 11](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/b655a783-a96a-4bcf-85d8-5da351ce8bf7)
