### PR TITLE
Network 요청 변경, Result Sugar 추가

### DIFF
--- a/client/Targets/Core/CoreKit/Sources/CoreUtil/Result+Scheduler.swift
+++ b/client/Targets/Core/CoreKit/Sources/CoreUtil/Result+Scheduler.swift
@@ -1,0 +1,70 @@
+//
+//  Result+.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 11/19/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public enum ResultScheduler {
+    case main
+    case global
+    case current
+    
+    func exeucte(_ handler: @escaping () -> Void) {
+        switch self {
+        case .main:
+            DispatchQueue.main.async {
+                handler()
+            }
+            
+        case .global:
+            DispatchQueue.global().async {
+                handler()
+            }
+            
+        case .current:
+            handler()
+        }
+    }
+}
+
+public extension Result {
+    
+    @discardableResult
+    func onSuccess(
+        on scheduler: ResultScheduler = .current,
+        _ execute: @escaping (Success) -> Void
+    ) -> Self {
+        switch self {
+        case .success(let value):
+            scheduler.exeucte {
+                execute(value)
+            }
+            return self
+            
+        default:
+            return self
+        }
+    }
+    
+    @discardableResult
+    func onFailure(
+        on scheduler: ResultScheduler = .current,
+        _ execute: @escaping (Failure) -> Void
+    ) -> Self {
+        switch self {
+        case .failure(let error):
+            scheduler.exeucte {
+                execute(error)
+            }
+            return self
+            
+        default:
+            return self
+        }
+    }
+    
+}

--- a/client/Targets/Core/CoreKit/Sources/CoreUtil/Result+Scheduler.swift
+++ b/client/Targets/Core/CoreKit/Sources/CoreUtil/Result+Scheduler.swift
@@ -1,5 +1,5 @@
 //
-//  Result+.swift
+//  Result+Scheduler.swift
 //  CoreKit
 //
 //  Created by 홍성준 on 11/19/23.
@@ -9,6 +9,7 @@
 import Foundation
 
 public enum ResultScheduler {
+    
     case main
     case global
     case current
@@ -29,6 +30,7 @@ public enum ResultScheduler {
             handler()
         }
     }
+    
 }
 
 public extension Result {
@@ -51,6 +53,25 @@ public extension Result {
     }
     
     @discardableResult
+    func onSuccess<T: AnyObject>(
+        on scheduler: ResultScheduler = .current,
+        with unretainObject: T,
+        _ execute: @escaping (T, Success) -> Void
+    ) -> Self {
+        switch self {
+        case .success(let value):
+            scheduler.exeucte { [weak unretainObject] in
+                guard let object = unretainObject else { return }
+                execute(object, value)
+            }
+            return self
+            
+        default:
+            return self
+        }
+    }
+    
+    @discardableResult
     func onFailure(
         on scheduler: ResultScheduler = .current,
         _ execute: @escaping (Failure) -> Void
@@ -59,6 +80,25 @@ public extension Result {
         case .failure(let error):
             scheduler.exeucte {
                 execute(error)
+            }
+            return self
+            
+        default:
+            return self
+        }
+    }
+    
+    @discardableResult
+    func onFailure<T: AnyObject>(
+        on scheduler: ResultScheduler = .current,
+        with unretainObject: T,
+        _ execute: @escaping (T, Failure) -> Void
+    ) -> Self {
+        switch self {
+        case .failure(let error):
+            scheduler.exeucte { [weak unretainObject] in
+                guard let object = unretainObject else { return }
+                execute(object, error)
             }
             return self
             

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/Network.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/Network.swift
@@ -11,6 +11,6 @@ import Combine
 
 public protocol Network {
     
-    func request<T: Decodable>(_ target: any Target) -> AnyPublisher<T, Error>
+    func request<T: Decodable>(_ target: any Target) async -> Result<T, Error>
     
 }

--- a/client/Targets/Data/Repositories/Sources/AuthRepository.swift
+++ b/client/Targets/Data/Repositories/Sources/AuthRepository.swift
@@ -22,22 +22,18 @@ public final class AuthRepository: AuthRepositoryInterface {
         self.session = session
     }
     
-    public func requestSignIn(token: String) -> AnyPublisher<AuthToken, Error> {
+    public func requestSignIn(token: String) async -> Result<AuthToken, Error> {
         let requestDTO = SignInRequestDTO(OAuthToken: token)
         let target = SignInTarget(task: .json(requestDTO))
-        let request: AnyPublisher<SignInResponseDTO, Error> = session.request(target)
-        return request
-            .map { $0.toDomain() }
-            .eraseToAnyPublisher()
+        let request: Result<SignInResponseDTO, Error> = await session.request(target)
+        return request.map { $0.toDomain() }
     }
     
-    public func requestSignUp(token: String, userName: String) -> AnyPublisher<AuthToken, Error> {
+    public func requestSignUp(token: String, userName: String) async -> Result<AuthToken, Error> {
         let requestDTO = SignUpRequestDTO(OAuthToken: token, username: userName)
         let target = SignUpTarget(task: .json(requestDTO))
-        let request: AnyPublisher<SignUpResponseDTO, Error> = session.request(target)
-        return request
-            .map { $0.toDomain() }
-            .eraseToAnyPublisher()
+        let request: Result<SignUpResponseDTO, Error> = await session.request(target)
+        return request.map { $0.toDomain() }
     }
     
 }

--- a/client/Targets/Domain/Interfaces/Sources/Repository/AuthRepositoryInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/Repository/AuthRepositoryInterface.swift
@@ -6,13 +6,12 @@
 //  Copyright © 2023 codesquad. All rights reserved.
 //
 
-import Combine
 import Foundation
 import DomainEntities
 
 public protocol AuthRepositoryInterface: AnyObject {
     
-    func requestSignIn(token: String) -> AnyPublisher<AuthToken, Error>
-    func requestSignUp(token: String, userName: String) -> AnyPublisher<AuthToken, Error>
+    func requestSignIn(token: String) async -> Result<AuthToken, Error>
+    func requestSignUp(token: String, userName: String) async -> Result<AuthToken, Error>
     
 }

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/AuthUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/AuthUseCaseInterface.swift
@@ -14,7 +14,7 @@ public protocol AuthUseCaseInterface: AnyObject {
     
     var naverToken: AnyPublisher<String, Never> { get }
     func requestNaverSignIn()
-    func requestSignIn(token: String) -> AnyPublisher<AuthToken, Error>
-    func requestSignUp(userName: String) -> AnyPublisher<AuthToken, Error>
+    func requestSignIn(token: String) async -> Result<AuthToken, Error>
+    func requestSignUp(userName: String) async -> Result<AuthToken, Error>
     
 }

--- a/client/Targets/Domain/UseCases/Sources/AuthUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/AuthUseCase.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 codesquad. All rights reserved.
 //
 
+import Foundation
 import Combine
 import Foundation
 import DomainEntities
@@ -36,20 +37,18 @@ public final class AuthUseCase: AuthUseCaseInterface {
         signInUseCase.requestNaverLogin()
     }
     
-    public func requestSignIn(token: String) -> AnyPublisher<AuthToken, Error> {
-        return repository
+    public func requestSignIn(token: String) async -> Result<AuthToken, Error> {
+        return await repository
             .requestSignIn(token: token)
-            .eraseToAnyPublisher()
     }
     
-    public func requestSignUp(userName: String) -> AnyPublisher<AuthToken, Error> {
+    public func requestSignUp(userName: String) async -> Result<AuthToken, Error> {
         guard let token = currentToken.value else {
             let error = NetworkError.unknown("Empty Token")
-            return Fail(error: error).eraseToAnyPublisher()
+            return .failure(error)
         }
-        return repository
+        return await repository
             .requestSignUp(token: token, userName: userName)
-            .eraseToAnyPublisher()
     }
     
     private func receiveNaverToken() {

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignIn/SignInInteractor.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignIn/SignInInteractor.swift
@@ -10,7 +10,7 @@ import Combine
 import Foundation
 
 import ModernRIBs
-
+import CoreKit
 import DomainInterfaces
 
 protocol SignInRouting: ViewableRouting {
@@ -58,9 +58,8 @@ final class SignInInteractor: PresentableInteractor<SignInPresentable>, SignInIn
 
     override func didBecomeActive() {
         super.didBecomeActive()
-        
     }
-
+    
     override func willResignActive() {
         super.willResignActive()
     }
@@ -74,17 +73,15 @@ final class SignInInteractor: PresentableInteractor<SignInPresentable>, SignInIn
     }
     
     private func requestSignIn(token: String) {
-        dependency.authUseCase
-            .requestSignIn(token: token)
-            .receive(on: DispatchQueue.main)
-            .sink(
-                receiveCompletion: { _ in }, 
-                receiveValue: { [weak self] token in
+        Task { [weak self] in
+            guard let self else { return }
+            await dependency.authUseCase
+                .requestSignIn(token: token)
+                .onSuccess(on: .main, with: self) { this, token in
                     print(token)
-                    self?.router?.attachSignUp()
+                    this.router?.attachSignUp()
                 }
-            )
-            .store(in: &cancellables)
+        }
     }
     
     // MARK: - SignUp


### PR DESCRIPTION
## 🌁 배경
* close #151 
* **후술할 방법보다 괜찮은 방법 있으면 꼭 말씀해주세요**
* 전에 얘기가 나왔던 Combine 덜어내기 했습니다.
* 데이터 스트림이 필요한 경우에는 Combine이 필요해서 두었고 1회 호출만 필요한 단순한 요청은 async/await 으로 변경했습니다.
* Task로 감싸서 실행을 하다 보니 메인 스레드 이슈가 있어서 Result 타입에 코드를 추가했습니다 (CoreKit을 import해야 사용 가능)
* onSuccess(+onFailure)를 호출할 때 Scheduler 그리고 참조를 할 객체를 넘길 수 있습니다.
   * 참조는 약한 참조로 진행하며 객체를 가져올 수 없을 때는 호출되지 않습니다.
```swift
// 적용하기 전
Task { [weak self] in
    guard let self else { return }
    let result = await dependency.authUseCase
        .requestSignUp(userName: userNameSubject.value)
    switch result {
    case .success(let value):
         DispatchQueue.main.async { [weak self] in
               self?.listener?.signUpDidComplete()
         }
    case .failure(let error):
          print(error.localizedDescription)

}

// 적용한 후
Task { [weak self] in
    guard let self else { return }
    await dependency.authUseCase
        .requestSignUp(userName: userNameSubject.value)
        .onSuccess(on: .main, with: self, { this, token in
            this.listener?.signUpDidComplete()
        })
        .onFailure { error in
            print(error.localizedDescription)
        }
}

```

## ✅ 수정 내역
* Network 요청 방식 변경 (combine -> async/await)
* Result 타입 Sugar 코드 추가

