### PR TITLE
로그인/회원가입 API 연결

### DIFF
--- a/client/Targets/Core/Network/NetworkAPIAuth/Sources/URLProtocols/AuthURLProtocol.swift
+++ b/client/Targets/Core/Network/NetworkAPIAuth/Sources/URLProtocols/AuthURLProtocol.swift
@@ -40,14 +40,14 @@ public final class AuthURLProtocol: URLProtocol {
     
     private func signInResponseMock() -> Data {
         let parameters: [String: Any] = [
-            "token": "signInResponseMock"
+            "accessToken": "signInResponseMock"
         ]
         return makeMock(paramters: parameters)
     }
     
     private func signUpResponseMock() -> Data {
         let parameters: [String: Any] = [
-            "token": "signUpResponseMock"
+            "accessToken": "signUpResponseMock"
         ]
         return makeMock(paramters: parameters)
     }

--- a/client/Targets/Data/Network/Sources/Auth/SignInResponseDTO.swift
+++ b/client/Targets/Data/Network/Sources/Auth/SignInResponseDTO.swift
@@ -11,14 +11,14 @@ import DomainEntities
 
 public struct SignInResponseDTO: Decodable {
     
-    public let token: String
+    public let accessToken: String
     
 }
 
 public extension SignInResponseDTO {
     
     func toDomain() -> AuthToken {
-        return AuthToken(token: token)
+        return AuthToken(token: accessToken)
     }
     
 }

--- a/client/Targets/Data/Network/Sources/Auth/SignUpResponseDTO.swift
+++ b/client/Targets/Data/Network/Sources/Auth/SignUpResponseDTO.swift
@@ -11,14 +11,14 @@ import DomainEntities
 
 public struct SignUpResponseDTO: Decodable {
     
-    public let token: String
+    public let accessToken: String
     
 }
 
 public extension SignUpResponseDTO {
     
     func toDomain() -> AuthToken {
-        return AuthToken(token: token)
+        return AuthToken(token: accessToken)
     }
     
 }

--- a/client/Targets/Data/Repositories/Sources/NaverLoginRepository.swift
+++ b/client/Targets/Data/Repositories/Sources/NaverLoginRepository.swift
@@ -33,12 +33,8 @@ public final class NaverLoginRepository: NSObject, NaverLoginRepositoryInterface
     }
     
     public func requestLogin() {
-        guard let token = instance?.accessToken else {
-            instance?.delegate = self
-            instance?.requestThirdPartyLogin()
-            return
-        }
-        accessTokenCurrentValue.send(token)
+        instance?.delegate = self
+        instance?.requestThirdPartyLogin()
     }
     
 }
@@ -51,6 +47,8 @@ extension NaverLoginRepository: NaverThirdPartyLoginConnectionDelegate {
     }
     
     public func oauth20ConnectionDidFinishRequestACTokenWithRefreshToken() {
+        guard let token = instance?.accessToken else { return }
+        accessTokenCurrentValue.send(token)
         
     }
     

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignIn/SignInInteractor.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignIn/SignInInteractor.swift
@@ -77,9 +77,15 @@ final class SignInInteractor: PresentableInteractor<SignInPresentable>, SignInIn
             guard let self else { return }
             await dependency.authUseCase
                 .requestSignIn(token: token)
-                .onSuccess(on: .main, with: self) { this, token in
-                    print(token)
-                    this.router?.attachSignUp()
+                .onSuccess(on: .main, with: self) { this, authToken in
+                    if authToken.token.isEmpty {
+                        this.router?.attachSignUp()
+                    } else {
+                        this.router?.attachLocationAuthority()
+                    }
+                }
+                .onFailure { error in
+                    Log.make(message: error.localizedDescription, log: .interactor)
                 }
         }
     }


### PR DESCRIPTION
## 🌁 배경
* close #89 
* 구두로 얘기했던 로그인/회원가입 API 연결 추가했습니다.
* 네이버 로그인 요청이 변경되었습니다.
  * 기존 - Instance에 토큰이 있으면 해당 토큰을 재사용하였음
  * 현재 - 반드시 요청을 하도록 변경하였음 (refreshToken을 받는 항목도 추가함)

## ✅ 수정 내역
* 로그인/회원가입 Response 변경
* 로그인/회원가입 분기 처리 추가 (토큰 여부에 따라)
* Naver 로그인 Token 요청 방식 변경

## ⚙️ 테스트 방법
* AppRootComponent에 있는 Network Configuration을 수정하면 됩니다.
```swift
// 기존
override init(dependency: AppRootDependency) {
        let naverLoginRepository: NaverLoginRepositoryInterface = {
            let repository = NaverLoginRepository()
            repository.setup()
            return repository
        }()
        self.naverLoginRepository = naverLoginRepository
        let network: Network = {
//            let configuration = URLSessionConfiguration.default
            let configuration = URLSessionConfiguration.ephemeral
            configuration.protocolClasses = [AuthURLProtocol.self]
            let provider = NetworkProvider(session: URLSession(configuration: configuration))
            return provider
        }()
        self.authUseCase = AuthUseCase(
            repository: AuthRepository(session: network),
            signInUseCase: SignInUseCase(naverLoginRepository: naverLoginRepository)
        )
        self.locationAuthorityUseCase = LocationAuthorityUseCase(service: LocationService())
        super.init(dependency: dependency)
    }

// 서버 호출
override init(dependency: AppRootDependency) {
//      생략
        let network: Network = {
            let configuration = URLSessionConfiguration.default
//            let configuration = URLSessionConfiguration.ephemeral
//            configuration.protocolClasses = [AuthURLProtocol.self]
            let provider = NetworkProvider(session: URLSession(configuration: configuration))
            return provider
        }()
//     생략
    }
```
