### PR TITLE
Test Target 추가

### DIFF
--- a/client/Targets/Data/Network/Project.swift
+++ b/client/Targets/Data/Network/Project.swift
@@ -4,7 +4,7 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "DataNetwork",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: [
         .Target.Domain.Entities,
     ]

--- a/client/Targets/Data/Network/Tests/Sources/dummy.swift
+++ b/client/Targets/Data/Network/Tests/Sources/dummy.swift
@@ -1,0 +1,1 @@
+// dummy.swift

--- a/client/Targets/Data/Repositories/Project.swift
+++ b/client/Targets/Data/Repositories/Project.swift
@@ -4,7 +4,7 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "DataRepositories",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: [
         .Target.Domain.Interfaces,
         .Target.Data.Network

--- a/client/Targets/Data/Repositories/Tests/Sources/dummy.swift
+++ b/client/Targets/Data/Repositories/Tests/Sources/dummy.swift
@@ -1,0 +1,1 @@
+// dummy.swift

--- a/client/Targets/Data/Storages/Project.swift
+++ b/client/Targets/Data/Storages/Project.swift
@@ -4,6 +4,6 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "DataStorages",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: []
 )

--- a/client/Targets/Data/Storages/Tests/Sources/dummy.swift
+++ b/client/Targets/Data/Storages/Tests/Sources/dummy.swift
@@ -1,0 +1,1 @@
+// dummy.swift

--- a/client/Targets/Domain/UseCases/Project.swift
+++ b/client/Targets/Domain/UseCases/Project.swift
@@ -4,7 +4,7 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "DomainUseCases",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: [
         .Target.Domain.Interfaces,
     ]

--- a/client/Targets/Domain/UseCases/Tests/Sources/dummy.swift
+++ b/client/Targets/Domain/UseCases/Tests/Sources/dummy.swift
@@ -1,0 +1,1 @@
+// dummy.swift

--- a/client/Targets/Presentation/Auth/Implementations/Project.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Project.swift
@@ -4,7 +4,7 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "AuthImplementations",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: [
         .Target.Presentation.Auth.Interfaces,
         .Target.Domain.UseCases

--- a/client/Targets/Presentation/Auth/Implementations/Tests/Sources/dummy.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Tests/Sources/dummy.swift
@@ -1,0 +1,1 @@
+// dummy.swift

--- a/client/Targets/Presentation/Home/Implementations/Project.swift
+++ b/client/Targets/Presentation/Home/Implementations/Project.swift
@@ -4,7 +4,7 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "HomeImplementations",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: [
         .Target.Presentation.Home.Interfaces,
     ]

--- a/client/Targets/Presentation/Home/Implementations/Tests/Sources/dummy.swift
+++ b/client/Targets/Presentation/Home/Implementations/Tests/Sources/dummy.swift
@@ -1,0 +1,1 @@
+// dummy.swift

--- a/client/Targets/Presentation/Search/Implementations/Project.swift
+++ b/client/Targets/Presentation/Search/Implementations/Project.swift
@@ -4,7 +4,7 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "SearchImplementations",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: [
         .Target.Presentation.Search.Interfaces,
     ]

--- a/client/Targets/Presentation/Search/Implementations/Tests/Sources/dummy.swift
+++ b/client/Targets/Presentation/Search/Implementations/Tests/Sources/dummy.swift
@@ -1,0 +1,1 @@
+// dummy.swift

--- a/client/Targets/Presentation/Story/Implementations/Project.swift
+++ b/client/Targets/Presentation/Story/Implementations/Project.swift
@@ -4,7 +4,7 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "StoryImplementations",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: [
         .Target.Presentation.Story.Interfaces,
     ]

--- a/client/Targets/Presentation/Story/Implementations/Tests/Sources/dummy.swift
+++ b/client/Targets/Presentation/Story/Implementations/Tests/Sources/dummy.swift
@@ -1,0 +1,1 @@
+// dummy.swift

--- a/client/Tuist/Stencils/Project-implementations.stencil
+++ b/client/Tuist/Stencils/Project-implementations.stencil
@@ -4,7 +4,7 @@ import UtilityPlugin
 
 let project = Project.framework(
     name: "{{ name }}Implementations",
-    featureTargets: [.staticLibrary],
+    featureTargets: [.staticLibrary, .tests],
     dependencies: [
         .Target.Presentation.{{ name }}.Interfaces,
     ]

--- a/client/Tuist/Templates/feature/feature.swift
+++ b/client/Tuist/Templates/feature/feature.swift
@@ -64,6 +64,10 @@ let implementationItems:  [ProjectDescription.Template.Item] = [
         path: "\(nameAttribute)/Implementations/Resources/dummy.txt",
         contents: "dummy"
     ),
+    .string(
+        path: "\(nameAttribute)/Implementations/Tests/Sources/\(nameAttribute)Tests.swift",
+        contents: "//\(nameAttribute)Tests.swift"
+    )
 ]
 
 let template = Template(


### PR DESCRIPTION
## 🌁 배경
* close #166 
* 하단에 작성한 곳 Test 가능하도록 하였습니다.
  * Presentation 모듈에는 Implementations 에 테스트 가능하도록 설정
  * Data -> DataNetwork, DataRepositories
  * Domain -> DomainUseCase

## ✅ 수정 내역
* Project Test Target 추가
* Tests 더미 데이터 추가

## ⚙️ 테스트 방법
* tuist generate 후 각 모듈의 Tests 폴더에서 UnitTest를 추가해서 실행하면 됩니다.

## 📕 리뷰 노트
* 추후 테스트 타겟을 추가하려면 Project에 .tests 추가 및 Tests폴더와 더미 데이터를 추가하면 됩니다.

