### PR TITLE
AccessToken Setup 추가

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootBuilder.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootBuilder.swift
@@ -30,7 +30,7 @@ final class AppRootBuilder: Builder<AppRootDependency>, AppRootBuildable {
         
         let component = AppRootComponent(dependency: dependency)
         let tabBarController = AppRootTabBarController()
-        let interactor = AppRootInteractor(presenter: tabBarController)
+        let interactor = AppRootInteractor(presenter: tabBarController, dependency: component)
         
         return AppRootRouter(
             interactor: interactor,

--- a/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
@@ -24,6 +24,7 @@ import StoryImplementations
 
 final class AppRootComponent: Component<AppRootDependency>,
                               AppRootRouterDependency,
+                              AppRootInteractorDependency,
                               SignInDependency,
                               HomeDependency,
                               SearchHomeDependency, 

--- a/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
@@ -7,6 +7,7 @@
 //
 
 import ModernRIBs
+import DomainInterfaces
 
 protocol AppRootRouting: ViewableRouting {
     func attachSignIn()
@@ -23,22 +24,29 @@ protocol AppRootListener: AnyObject {
     
 }
 
+protocol AppRootInteractorDependency: AnyObject {
+    var authUseCase: AuthUseCaseInterface { get }
+}
+
 final class AppRootInteractor: PresentableInteractor<AppRootPresentable>, AppRootInteractable, AppRootPresentableListener {
 
     weak var router: AppRootRouting?
     weak var listener: AppRootListener?
     
-    // TODO: - 인증 서비스에서 판단하기
-    private var isUserAuthorized: Bool = false
+    private let dependency: AppRootInteractorDependency
     
-    override init(presenter: AppRootPresentable) {
+    init(
+        presenter: AppRootPresentable,
+        dependency: AppRootInteractorDependency
+    ) {
+        self.dependency = dependency
         super.init(presenter: presenter)
         presenter.listener = self
     }
 
     override func didBecomeActive() {
         super.didBecomeActive()
-        if isUserAuthorized {
+        if dependency.authUseCase.isAuthorized {
             router?.attachTabs()
         } else {
             router?.attachSignIn()

--- a/client/Targets/Core/CoreKit/Sources/SecretUtil/SecretManager.swift
+++ b/client/Targets/Core/CoreKit/Sources/SecretUtil/SecretManager.swift
@@ -1,0 +1,41 @@
+//
+//  SecretManager.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 11/21/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public enum SecretManager {
+    
+    public enum SecretType: String {
+        case accessToken
+    }
+    
+    public static func read(type: SecretType) -> Data? {
+        let query = NSDictionary(dictionary: [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: type.rawValue,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ])
+        var data: AnyObject?
+        _ = withUnsafeMutablePointer(to: &data) {
+            SecItemCopyMatching(query, UnsafeMutablePointer($0))
+        }
+        return data as? Data
+    }
+    
+    public static func write(type: SecretType, data: Data) {
+        let query = NSDictionary(dictionary: [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: type.rawValue,
+            kSecValueData: data
+        ])
+        SecItemDelete(query)
+        SecItemAdd(query, nil)
+    }
+    
+}

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkHeader.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkHeader.swift
@@ -23,8 +23,8 @@ public class NetworkHeader {
     }
     
     @discardableResult
-    public func authToken(_ value: String) -> Self {
-        headers["Auth-Token"] = value
+    public func accessToken(_ value: String) -> Self {
+        headers["accessToken"] = value
         return self
     }
     

--- a/client/Targets/Data/Network/Auth/Sources/AuthAPI.swift
+++ b/client/Targets/Data/Network/Auth/Sources/AuthAPI.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import BaseAPI
 import NetworkAPIKit
 
 public enum AuthAPI {

--- a/client/Targets/Data/Network/Base/Sources/NetworkHeader+Authorized.swift
+++ b/client/Targets/Data/Network/Base/Sources/NetworkHeader+Authorized.swift
@@ -1,0 +1,27 @@
+//
+//  NetworkHeader+Authorized.swift
+//  BaseAPI
+//
+//  Created by 홍성준 on 11/21/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import CoreKit
+import NetworkAPIKit
+
+public extension NetworkHeader {
+    
+    static var token: String? {
+        guard let data = SecretManager.read(type: .accessToken) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+    
+    static var authorized: NetworkHeader {
+        guard let token = token else { return .default }
+        return .default.accessToken(token)
+    }
+    
+}

--- a/client/Targets/Data/Network/Base/Sources/dummy.swift
+++ b/client/Targets/Data/Network/Base/Sources/dummy.swift
@@ -1,1 +1,0 @@
-// dummy.swift

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/AuthUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/AuthUseCaseInterface.swift
@@ -13,6 +13,7 @@ import DomainEntities
 public protocol AuthUseCaseInterface: AnyObject {
     
     var naverToken: AnyPublisher<String, Never> { get }
+    var isAuthorized: Bool { get }
     func requestNaverSignIn()
     func requestSignIn(token: String) async -> Result<AuthToken, Error>
     func requestSignUp(userName: String) async -> Result<AuthToken, Error>

--- a/client/Targets/Domain/UseCases/Sources/AuthUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/AuthUseCase.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Combine
 import Foundation
+import CoreKit
 import DomainEntities
 import DomainInterfaces
 import NetworkAPIKit
@@ -38,8 +39,9 @@ public final class AuthUseCase: AuthUseCaseInterface {
     }
     
     public func requestSignIn(token: String) async -> Result<AuthToken, Error> {
-        return await repository
-            .requestSignIn(token: token)
+        let result = await repository.requestSignIn(token: token)
+        saveAccessTokenIfEnabled(result: result)
+        return result
     }
     
     public func requestSignUp(userName: String) async -> Result<AuthToken, Error> {
@@ -47,8 +49,9 @@ public final class AuthUseCase: AuthUseCaseInterface {
             let error = NetworkError.unknown("Empty Token")
             return .failure(error)
         }
-        return await repository
-            .requestSignUp(token: token, userName: userName)
+        let result = await repository.requestSignUp(token: token, userName: userName)
+        saveAccessTokenIfEnabled(result: result)
+        return result
     }
     
     private func receiveNaverToken() {
@@ -59,5 +62,15 @@ public final class AuthUseCase: AuthUseCaseInterface {
             })
             .store(in: &cancellables)
     }
+    
+    private func saveAccessTokenIfEnabled(result: Result<AuthToken, Error>) {
+        guard case let .success(authToken) = result,
+              let data = authToken.token.data(using: .utf8)
+        else {
+            return
+        }
+        SecretManager.write(type: .accessToken, data: data)
+    }
+    
     
 }

--- a/client/Targets/Domain/UseCases/Sources/AuthUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/AuthUseCase.swift
@@ -20,6 +20,14 @@ public final class AuthUseCase: AuthUseCaseInterface {
         return signInUseCase.naverAcessToken
     }
     
+    public var isAuthorized: Bool {
+        guard let data = SecretManager.read(type: .accessToken),
+              let token = String(data: data, encoding: .utf8) else {
+            return false
+        }
+        return !token.isEmpty
+    }
+    
     private let repository: AuthRepositoryInterface
     private let signInUseCase: SignInUseCaseInterface
     private var currentToken = CurrentValueSubject<String?, Never>(nil)


### PR DESCRIPTION
## 🌁 배경
* close #182 
* 추후 API 에서 Header를 설정할 때 BaseAPI를 import 하고 .authorized 를 사용하시면 자동으로 인증된 헤더를 사용하게 됩니다.
* **🚨현재 Mock으로 로그인 요청을 하고 있어서 로그인 요청하면 Mock Access Token이 저장되니까 주의해주세요!**

## ✅ 수정 내역
* SecretManager 추가
* Authorized Header 추가
* Root에 로그인 여부 처리 추가

## ⚙️ 테스트 방법
* 처음에 앱을 실행하면 로그인 되지 않은 상태로 시작
* 로그인 후 앱을 종료하면 다음부터 로그인된 상태로 시작

## 📕 리뷰 노트
* [SecretManager 레퍼런스](https://github.com/Nexters/phochak-iOS/blob/develop/Targets/Core/Sources/AuthManager.swift)