### PR TITLE
대표 뱃지 설정 기능 구현

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -2,10 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { UserRepository } from './../user/user.repository';
 import { JwtService } from '@nestjs/jwt';
 import { User } from 'src/entities/user.entity';
-import { idDuplicatedException } from 'src/exception/cuntom.exception/id.duplicate.exception';
+import { idDuplicatedException } from 'src/exception/custom.exception/id.duplicate.exception';
 import { profileImage } from 'src/entities/profileImage.entity';
 import { ImageService } from '../image/image.service';
-import { invalidTokenException } from 'src/exception/cuntom.exception/token.invalid.exception';
+import { invalidTokenException } from 'src/exception/custom.exception/token.invalid.exception';
 
 @Injectable()
 export class AuthService {

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -46,4 +46,8 @@ export class User {
 
   @OneToMany(() => Badge, (badge) => badge.user, { cascade: true })
   badges: Promise<Badge[]>;
+
+  @OneToOne(() => Badge)
+  @JoinColumn()
+  representativeBadge: Badge;
 }

--- a/server/src/exception/custom.exception/badge.notValid.exception.ts
+++ b/server/src/exception/custom.exception/badge.notValid.exception.ts
@@ -1,0 +1,7 @@
+import { ConflictException } from '@nestjs/common';
+
+export class InvalidBadgeException extends ConflictException {
+  constructor() {
+    super('Valid 하지 않은 Badge Name입니다.');
+  }
+}

--- a/server/src/story/story.service.ts
+++ b/server/src/story/story.service.ts
@@ -69,9 +69,8 @@ export class StoryService {
     return stories;
   }
 
-
   async getRecommendByLocationStory(locationDto: LocationDTO) {
-    const stories = await this.storyRepository.getStoryByCondition({ where: { likeCount: MoreThan(10) }, take: 10 });
+    const stories = await this.storyRepository.getStoryByCondition({ where: { likeCount: MoreThan(10) }, take: 10, relations: ['user'] });
 
     const userLatitude = locationDto.latitude;
     const userLongitude = locationDto.longitude;
@@ -100,6 +99,7 @@ export class StoryService {
           likeCount: 'DESC',
         },
         take: 10,
+        relations: ['user'],
       });
       return stories;
     } catch (error) {
@@ -107,7 +107,6 @@ export class StoryService {
     }
   }
 
-  
   public async update(accessToken: string, { storyId, title, content, category, place, images, date }): Promise<number> {
     const newStory = await createStoryEntity({ title, content, category, place, images, date });
     const decodedToken = this.jwtService.verify(accessToken);

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -9,13 +9,15 @@ export class UserController {
   constructor(private userService: UserService) {}
 
   @Post('badge')
-  @ApiOperation({ summary: 'Add a new badge to a user' })
-  @ApiResponse({ status: 201, description: 'Badge가 성공적으로 추가되었습니다.' })
+  @ApiOperation({ summary: '유제 객체에 새로운 뱃지를 추가합니다.' })
+  @ApiResponse({ status: 200, description: 'Badge가 성공적으로 추가되었습니다.' })
   async addBadge(@Body() addBadgeDto: AddBadgeDto) {
     return this.userService.addNewBadge(addBadgeDto);
   }
 
   @Put('badge')
+  @ApiOperation({ summary: '유저 객체의 대표 뱃지를 설정합니다.' })
+  @ApiResponse({ status: 200, description: '대표 뱃지가 성공적으로 변경되었습니다.' })
   async setRepresentatvieBadge(@Body() setBadgeDto: AddBadgeDto) {
     return this.userService.setRepresentatvieBadge(setBadgeDto);
   }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -16,5 +16,7 @@ export class UserController {
   }
 
   @Put('badge')
-  async setBadge(@Body() addBadgeDto: AddBadgeDto) {}
+  async setRepresentatvieBadge(@Body() setBadgeDto: AddBadgeDto) {
+    return this.userService.setRepresentatvieBadge(setBadgeDto);
+  }
 }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Put } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UserService } from './user.service';
 import { AddBadgeDto } from './dto/addBadge.dto';
@@ -14,4 +14,7 @@ export class UserController {
   async addBadge(@Body() addBadgeDto: AddBadgeDto) {
     return this.userService.addNewBadge(addBadgeDto);
   }
+
+  @Put('badge')
+  async setBadge(@Body() addBadgeDto: AddBadgeDto) {}
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -7,6 +7,7 @@ import { User } from 'src/entities/user.entity';
 import { Badge } from 'src/entities/badge.entity';
 import { AddBadgeDto } from './dto/addBadge.dto';
 import { InvalidIdException } from 'src/exception/custom.exception/id.notValid.exception';
+import { InvalidBadgeException } from 'src/exception/custom.exception/badge.notValid.exception';
 
 @Injectable()
 export class UserService {
@@ -51,8 +52,9 @@ export class UserService {
 
     const badgeList = await userObject[0].badges;
     const targetbadge = badgeList.find((badge) => badge.badgeName === badgeName);
-    userObject[0].representativeBadge = targetbadge;
+    if (!targetbadge) throw new InvalidBadgeException();
 
+    userObject[0].representativeBadge = targetbadge;
     this.userRepository.save(userObject[0]);
   }
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -41,4 +41,18 @@ export class UserService {
     userBadges.push(newBadge);
     this.userRepository.save(userObject[0]);
   }
+
+  async setRepresentatvieBadge(setBadgeDto: AddBadgeDto) {
+    const userId = setBadgeDto.userId;
+    const badgeName = setBadgeDto.badgeName;
+
+    const userObject = await this.userRepository.findByOption({ where: { userId: userId } });
+    if (userObject.length <= 0) throw new InvalidIdException();
+
+    const badgeList = await userObject[0].badges;
+    const targetbadge = badgeList.find((badge) => badge.badgeName === badgeName);
+    userObject[0].representativeBadge = targetbadge;
+
+    this.userRepository.save(userObject[0]);
+  }
 }


### PR DESCRIPTION
## 🌁 배경
* close #190 

## ✅ 수정 내역
- 유저가 대표 badge를 설정할 수 있도록 구현했습니다.

## ⚙️ 테스트 방법
- user/badge URI로 put 요청을 보내 실행시킬 수 있습니다
- 필요한 Body 데이터는 userId, BadgeName입니다.
- 유저가 가지고 있지 않은 BadgeName으로 설정하려 하는 경우, InvalidBadgeException이 발생합니다.

