### PR TITLE
스토리 생성 후 상세페이지 이동

### DIFF
--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorBuilder.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorBuilder.swift
@@ -19,7 +19,9 @@ public protocol StoryCreatorDependency: Dependency {}
 
 final class StoryCreatorComponent: Component<StoryCreatorDependency>,
                                    StoryCreatorRouterDependency,
-                                   StoryEditorDependency {
+                                   StoryEditorDependency,
+                                   StoryDetailDependency {
+    
     
     let network: Network = {
         let configuration = URLSessionConfiguration.default
@@ -32,6 +34,10 @@ final class StoryCreatorComponent: Component<StoryCreatorDependency>,
     lazy var storyUseCase: StoryUseCaseInterface = StoryUseCase(repository: StoryRepository(session: network))
     lazy var storyEditorBuilder: StoryEditorBuildable = {
         StoryEditorBuilder(dependency: self)
+    }()
+    
+    lazy var storyDetailBuilder: StoryDetailBuildable = {
+        StoryDetailBuilder(dependency: self)
     }()
 }
 

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreator/StoryCreatorInteractor.swift
@@ -8,9 +8,16 @@
 
 import ModernRIBs
 
+import DomainEntities
+
 public protocol StoryCreatorRouting: ViewableRouting {
     func attachStoryEditor()
     func detachStoryEditor()
+    
+    func attachStoryDetail(_ story: Story)
+    func detachStoryDetail()
+    
+    func routeToDetail(of story: Story)
 }
 
 public protocol StoryCreatorPresentable: Presentable {
@@ -26,8 +33,6 @@ final class StoryCreatorInteractor: PresentableInteractor<StoryCreatorPresentabl
     weak var router: StoryCreatorRouting?
     weak var listener: StoryCreatorListener?
 
-    // TODO: Add additional dependencies to constructor. Do not perform any logic
-    // in constructor.
     override init(presenter: StoryCreatorPresentable) {
         super.init(presenter: presenter)
         presenter.listener = self
@@ -50,5 +55,13 @@ final class StoryCreatorInteractor: PresentableInteractor<StoryCreatorPresentabl
         listener?.storyCreatorDidComplete()
     }
     
-
+    func storyDidCreate(_ story: Story) {
+        router?.routeToDetail(of: story)
+    }
+    
+    func storyDetailDidTapClose() {
+        router?.detachStoryDetail()
+        listener?.storyCreatorDidComplete()
+    }
+    
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/SimpleUserProfileView.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/SimpleUserProfileView.swift
@@ -47,7 +47,6 @@ extension UserStatus {
 
 final class SimpleUserProfileView: UIView {
     
-    private var listener: StoryDetailPresentableListener?
     private var cancellables = Set<AnyCancellable>()
     
     private let padding: CGFloat = 10
@@ -127,11 +126,6 @@ final class SimpleUserProfileView: UIView {
         setupViews()
     }
     
-    convenience init(listener: StoryDetailPresentableListener?) {
-        self.init()
-        self.listener = listener
-    }
-    
     override func layoutSubviews() {
         super.layoutSubviews()
         profileImage.layer.cornerRadius = 20
@@ -168,23 +162,12 @@ private extension SimpleUserProfileView {
             followButton.heightAnchor.constraint(equalToConstant: followButtonHeight)
         ])
     }
-    
-//    TODO: bind following button
-//    func bind() {
-//        listener?.userStatus
-//            .sink { status in
-//                followButton.image = status.image
-//            }.store(in: &cancellables)
-//    }
-    
+
 }
 
 // MARK: objc
 private extension SimpleUserProfileView {
     
-    @objc func followButtonDidTap() {
-//        TODO: add interactor function
-//        listener?.followButtonDidTap()
-    }
+    @objc func followButtonDidTap() { }
     
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/StoryHeaderView.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/StoryHeaderView.swift
@@ -12,8 +12,6 @@ import DesignKit
 
 final class StoryHeaderView: UIView {
     
-    private var listener: StoryDetailPresentableListener?
-
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .largeBold
@@ -41,7 +39,7 @@ final class StoryHeaderView: UIView {
     }()
     
     private lazy var storyLikesCommentsView: StoryLikesCommentsView = {
-        let likesCommentsView = StoryLikesCommentsView(listener: listener)
+        let likesCommentsView = StoryLikesCommentsView()
         
         likesCommentsView.translatesAutoresizingMaskIntoConstraints = false
         return likesCommentsView
@@ -55,11 +53,6 @@ final class StoryHeaderView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupViews()
-    }
-    
-    convenience init(listener: StoryDetailPresentableListener?) {
-        self.init()
-        self.listener = listener
     }
     
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/StoryLikesCommentsView.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/StoryLikesCommentsView.swift
@@ -10,17 +10,12 @@ import Combine
 import UIKit
 
 final class StoryLikesCommentsView: UIView {
-   
-    private var listener: StoryDetailPresentableListener?
-    
+       
     private lazy var likesImage: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(systemName: "heart")
         imageView.contentMode = .scaleAspectFill
         imageView.tintColor = .hpBlack
-        
-        let gesture = UITapGestureRecognizer(target: self, action: #selector(likesButtonDidTap))
-        imageView.addGestureRecognizer(gesture)
         
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
@@ -41,9 +36,6 @@ final class StoryLikesCommentsView: UIView {
         imageView.image = UIImage(systemName: "bubble")
         imageView.contentMode = .scaleAspectFill
         imageView.tintColor = .hpBlack
-        
-        let gesture = UITapGestureRecognizer(target: self, action: #selector(commentsButtonDidTap))
-        imageView.addGestureRecognizer(gesture)
          
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
@@ -67,11 +59,6 @@ final class StoryLikesCommentsView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupViews()
-    }
-    
-    convenience init(listener: StoryDetailPresentableListener?) {
-        self.init()
-        self.listener = listener
     }
     
 }
@@ -104,33 +91,6 @@ private extension StoryLikesCommentsView {
             commentsCountLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
             commentsCountLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
-    }
-    
-//    TODO: bind isLiked & likesCount
-//    func bind() {
-//        listener?.isLiked
-//            .sink { isLiked in
-//                likesImage.image = isLiked ? UIImage(systemName: "heart.fill") : UIImage(systemName: "heart")
-//            }.store(in: &cancellables)
-    
-//        listener?.likesCount
-//            .sink { count in
-//                likesCountLabel.text = "\(count)"
-//            }.store(in: &cancellables)
-//    }
-}
-
-// MARK: objc
-private extension StoryLikesCommentsView {
-    
-    @objc func likesButtonDidTap() {
-//        TODO: add listener function
-//        listener?.likesButtonDidTap()
-    }
-    
-    @objc func commentsButtonDidTap() {
-//        TODO: add listener function
-//        listener?.commentsButtonDidTap()
     }
     
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailBuilder.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailBuilder.swift
@@ -8,7 +8,7 @@
 
 import ModernRIBs
 
-protocol StoryDetailDependency: Dependency {
+public protocol StoryDetailDependency: Dependency {
     // TODO: Declare the set of dependencies required by this RIB, but cannot be
     // created by this RIB.
 }
@@ -20,17 +20,17 @@ final class StoryDetailComponent: Component<StoryDetailDependency> {
 
 // MARK: - Builder
 
-protocol StoryDetailBuildable: Buildable {
+public protocol StoryDetailBuildable: Buildable {
     func build(withListener listener: StoryDetailListener) -> StoryDetailRouting
 }
 
-final class StoryDetailBuilder: Builder<StoryDetailDependency>, StoryDetailBuildable {
+public final class StoryDetailBuilder: Builder<StoryDetailDependency>, StoryDetailBuildable {
 
-    override init(dependency: StoryDetailDependency) {
+    public override init(dependency: StoryDetailDependency) {
         super.init(dependency: dependency)
     }
 
-    func build(withListener listener: StoryDetailListener) -> StoryDetailRouting {
+    public func build(withListener listener: StoryDetailListener) -> StoryDetailRouting {
         let component = StoryDetailComponent(dependency: dependency)
         let viewController = StoryDetailViewController()
         let interactor = StoryDetailInteractor(presenter: viewController)

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailInteractor.swift
@@ -8,17 +8,15 @@
 
 import ModernRIBs
 
-protocol StoryDetailRouting: ViewableRouting {
-    // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
+public protocol StoryDetailRouting: ViewableRouting {
 }
 
 protocol StoryDetailPresentable: Presentable {
     var listener: StoryDetailPresentableListener? { get set }
-    // TODO: Declare methods the interactor can invoke the presenter to present data.
 }
 
-protocol StoryDetailListener: AnyObject {
-    // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
+public protocol StoryDetailListener: AnyObject {
+    func storyDetailDidTapClose()
 }
 
 final class StoryDetailInteractor: PresentableInteractor<StoryDetailPresentable>, StoryDetailInteractable, StoryDetailPresentableListener {
@@ -41,5 +39,9 @@ final class StoryDetailInteractor: PresentableInteractor<StoryDetailPresentable>
     override func willResignActive() {
         super.willResignActive()
         // TODO: Pause any business logic.
+    }
+    
+    func storyDetailDidTapClose() {
+        listener?.storyDetailDidTapClose()
     }
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailRouter.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailRouter.swift
@@ -8,12 +8,12 @@
 
 import ModernRIBs
 
-protocol StoryDetailInteractable: Interactable {
+public protocol StoryDetailInteractable: Interactable {
     var router: StoryDetailRouting? { get set }
     var listener: StoryDetailListener? { get set }
 }
 
-protocol StoryDetailViewControllable: ViewControllable {
+public protocol StoryDetailViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailViewController.swift
@@ -13,15 +13,28 @@ import ModernRIBs
 
 import DesignKit
 
-protocol StoryDetailPresentableListener: AnyObject {
-    // TODO: Declare properties and methods that the view controller can invoke to perform
-    // business logic, such as signIn(). This protocol is implemented by the corresponding
-    // interactor class.
+public protocol StoryDetailPresentableListener: AnyObject {
+    func storyDetailDidTapClose()
 }
 
 public final class StoryDetailViewController: UIViewController, StoryDetailPresentable, StoryDetailViewControllable {
     
+    private enum Constant {
+        static let navBarTitle = ""
+        static let scrollViewInset: CGFloat = 20
+        static let stackViewSpacing: CGFloat = 30
+    }
+    
     weak var listener: StoryDetailPresentableListener?
+    
+    private lazy var navigationView: NavigationView = {
+        let navigationView = NavigationView()
+        navigationView.setup(model: .init(title: Constant.navBarTitle, leftButtonType: .back, rightButtonTypes: [.none]))
+        navigationView.delegate = self
+        
+        navigationView.translatesAutoresizingMaskIntoConstraints = false
+        return navigationView
+    }()
     
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -44,7 +57,7 @@ public final class StoryDetailViewController: UIViewController, StoryDetailPrese
     }()
     
     private lazy var simpleUserProfileView: SimpleUserProfileView = {
-        let profileView = SimpleUserProfileView(listener: listener)
+        let profileView = SimpleUserProfileView()
         
         profileView.translatesAutoresizingMaskIntoConstraints = false
         return profileView
@@ -58,7 +71,7 @@ public final class StoryDetailViewController: UIViewController, StoryDetailPrese
     }()
 
     private lazy var storyHeaderView: StoryHeaderView = {
-        let subtitleView = StoryHeaderView(listener: listener)
+        let subtitleView = StoryHeaderView()
         
         subtitleView.translatesAutoresizingMaskIntoConstraints = false
         return subtitleView
@@ -73,6 +86,7 @@ public final class StoryDetailViewController: UIViewController, StoryDetailPrese
         textView.isUserInteractionEnabled = false
         textView.textContainerInset = .init(top: 0, left: 20, bottom: 0, right: 20)
         
+        textView.translatesAutoresizingMaskIntoConstraints = false
         return textView
     }()
     
@@ -85,15 +99,21 @@ public final class StoryDetailViewController: UIViewController, StoryDetailPrese
 private extension StoryDetailViewController {
     func setupViews() {
         view.backgroundColor = .hpWhite
-        view.addSubview(scrollView)
+        [navigationView, scrollView].forEach(view.addSubview)
+        
         scrollView.addSubview(stackView)
         [simpleUserProfileView, storyImagesView, storyHeaderView, bodyView].forEach(stackView.addArrangedSubview)
         
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationView.heightAnchor.constraint(equalToConstant: Constants.navigationViewHeight),
+            
+            scrollView.topAnchor.constraint(equalTo: navigationView.bottomAnchor, constant: Constant.scrollViewInset),
             scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
             scrollView.widthAnchor.constraint(equalTo: stackView.widthAnchor, multiplier: 1),
             
             stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
@@ -106,4 +126,12 @@ private extension StoryDetailViewController {
         
         bodyView.layoutIfNeeded()
     }
+}
+
+extension StoryDetailViewController: NavigationViewDelegate {
+   
+    public func navigationViewButtonDidTap(_ view: NavigationView, type: NavigationViewButtonType) {
+        listener?.storyDetailDidTapClose()
+    }
+
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorInteractor.swift
@@ -87,8 +87,8 @@ final class StoryEditorInteractor: PresentableInteractor<StoryEditorPresentable>
             guard let self else { return }
             await dependency.storyUseCase
                 .requestCreateStory(storyContent: content)
-                .onSuccess(on: .main, with: self, { [weak self] this, story in
-                    self?.listener?.storyDidCreate(story)
+                .onSuccess(on: .main, with: self, { this, story in
+                    this.listener?.storyDidCreate(story)
                 })
                 .onFailure { [weak self] error in
                     Log.make(message: error.localizedDescription, log: .interactor)

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorInteractor.swift
@@ -10,6 +10,7 @@ import Combine
 
 import ModernRIBs
 
+import CoreKit
 import DomainEntities
 import DomainInterfaces
 
@@ -20,11 +21,13 @@ public protocol StoryEditorRouting: ViewableRouting {
 public protocol StoryEditorPresentable: Presentable {
     var listener: StoryEditorPresentableListener? { get set }
     func setSaveButton(_ enabled: Bool)
+    func showFailure(_ error: Error)
 }
 
 public protocol StoryEditorListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
     func storyEditorDidTapClose()
+    func storyDidCreate(_ story: Story)
 }
 
 protocol StoryEditorInteractorDependency: AnyObject {
@@ -84,11 +87,12 @@ final class StoryEditorInteractor: PresentableInteractor<StoryEditorPresentable>
             guard let self else { return }
             await dependency.storyUseCase
                 .requestCreateStory(storyContent: content)
-                .onSuccess(on: .main, with: self, { this, sotryId in
-                    print("didTapSaveRequestNewStorySuccess on storyEditorInteractor")
+                .onSuccess(on: .main, with: self, { [weak self] this, story in
+                    self?.listener?.storyDidCreate(story)
                 })
-                .onFailure { error in
-                    print(error.localizedDescription)
+                .onFailure { [weak self] error in
+                    Log.make(message: error.localizedDescription, log: .interactor)
+                    self?.presenter.showFailure(error)
                 }
         }
     }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
@@ -120,6 +120,11 @@ final class StoryEditorViewController: UIViewController, StoryEditorPresentable,
         saveButton.isEnabled = enabled
     }
     
+    func showFailure(_ error: Error) {
+        let alert = UIAlertController(title: "스토리 생성 실패", message: "\(error.localizedDescription)", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "취소", style: .default))
+        present(alert, animated: true, completion: nil)
+    }
 }
 
 // MARK: - Setup Views


### PR DESCRIPTION
## 🌁 배경
* #239

## ✅ 수정 내역
* 스토리 생성 후 상세페이지로 이동하도록 router 로직 구현

## 📕 리뷰 노트
* `viewController.pushViewController`, `viewController.popViewController` 코드에 버그가 있을 수도 있습니다.
  * 지난번 `SignIn`과 마찬가지로 `popViewController`시에 memory leak error가 발생해서 `NavigationControllable`을 사용했습니다.

## 🎇 스크린샷
![Simulator Screen Recording - iPhone 15 Plus - 2023-11-22 at 21 40 12](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/f6061ccf-47bb-4a0c-ab3c-275a78de6405)