### PR TITLE
Demo 앱 Sugar 추가

### DIFF
--- a/client/Targets/Presentation/BasePresentation/Sources/Demo/DemoRootBuilder.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/Demo/DemoRootBuilder.swift
@@ -1,0 +1,38 @@
+//
+//  DemoRootBuilder.swift
+//  BasePresentation
+//
+//  Created by 홍성준 on 11/22/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+public protocol DemoRootDependency: Dependency {}
+
+public final class DemoRootComponent: Component<EmptyDependency>, DemoRootDependency {
+    
+    public init() {
+        super.init(dependency: EmptyComponent())
+    }
+    
+}
+
+protocol DemoRootBuildable: Buildable {
+    func build() -> DemoRootRouter
+}
+
+public final class DemoRootBuilder: Builder<DemoRootDependency>, DemoRootBuildable {
+
+    public override init(dependency: DemoRootDependency) {
+        super.init(dependency: dependency)
+    }
+
+    public func build() -> DemoRootRouter {
+        let component = DemoRootComponent()
+        let viewController = DemoRootViewController()
+        let interactor = DemoRootInteractor(presenter: viewController)
+        return DemoRootRouter(interactor: interactor, viewController: viewController)
+    }
+    
+}

--- a/client/Targets/Presentation/BasePresentation/Sources/Demo/DemoRootInteractor.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/Demo/DemoRootInteractor.swift
@@ -1,0 +1,38 @@
+//
+//  DemoRootInteractor.swift
+//  BasePresentation
+//
+//  Created by 홍성준 on 11/22/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+public protocol DemoRootRouting: ViewableRouting {
+    func attach(execute: (ViewControllable) -> Void)
+    func didBecomeActive()
+}
+
+protocol DemoRootPresentable: Presentable {
+    var listener: DemoRootPresentableListener? { get set }
+}
+
+final class DemoRootInteractor: PresentableInteractor<DemoRootPresentable>, DemoRootInteractable, DemoRootPresentableListener {
+    
+    weak var router: DemoRootRouting?
+    
+    override init(presenter: DemoRootPresentable) {
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+        router?.didBecomeActive()
+    }
+    
+    override func willResignActive() {
+        super.willResignActive()
+    }
+    
+}

--- a/client/Targets/Presentation/BasePresentation/Sources/Demo/DemoRootRouter.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/Demo/DemoRootRouter.swift
@@ -1,0 +1,38 @@
+//
+//  DemoRootRouter.swift
+//  BasePresentation
+//
+//  Created by 홍성준 on 11/22/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+public protocol DemoRootInteractable: Interactable {
+    var router: DemoRootRouting? { get set }
+}
+
+public protocol DemoRootViewControllable: ViewControllable {}
+
+public protocol DemoRootRouterListener: AnyObject {
+    func demoRootRouterDidBecomeActive()
+}
+
+public final class DemoRootRouter: LaunchRouter<DemoRootInteractable, DemoRootViewControllable>, DemoRootRouting {
+    
+    public weak var listener: DemoRootRouterListener?
+    
+    override init(interactor: DemoRootInteractable, viewController: DemoRootViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+    
+    public func attach(execute: (ViewControllable) -> Void) {
+        execute(viewController)
+    }
+    
+    public func didBecomeActive() {
+        listener?.demoRootRouterDidBecomeActive()
+    }
+    
+}

--- a/client/Targets/Presentation/BasePresentation/Sources/Demo/DemoRootViewController.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/Demo/DemoRootViewController.swift
@@ -1,0 +1,21 @@
+//
+//  DemoRootViewController.swift
+//  BasePresentation
+//
+//  Created by 홍성준 on 11/22/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+import UIKit
+
+protocol DemoRootPresentableListener: AnyObject {
+    // TODO: Declare properties and methods that the view controller can invoke to perform
+    // business logic, such as signIn(). This protocol is implemented by the corresponding
+    // interactor class.
+}
+
+final class DemoRootViewController: UIViewController, DemoRootPresentable, DemoRootViewControllable {
+
+    weak var listener: DemoRootPresentableListener?
+}

--- a/client/Targets/Presentation/Home/Demo/Project.swift
+++ b/client/Targets/Presentation/Home/Demo/Project.swift
@@ -7,5 +7,7 @@ let project = Project.demo(
     dependencies: [
         .Target.Presentation.Home.Interfaces,
         .Target.Presentation.Home.Implementations,
+        .Target.Data.Repositories,
+        .Target.Domain.UseCases
     ]
 )

--- a/client/Targets/Presentation/Home/Demo/Sources/AppDelegate.swift
+++ b/client/Targets/Presentation/Home/Demo/Sources/AppDelegate.swift
@@ -1,16 +1,53 @@
 import UIKit
+import HomeInterfaces
 import HomeImplementations
+import ModernRIBs
+import CoreKit
+import NetworkAPIKit
+import BasePresentation
+import DomainInterfaces
+import DomainUseCases
+import DataRepositories
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    
     var window: UIWindow?
+    
+    private var launchRouter: DemoRootRouter?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window
-        let viewController = UIViewController()
-        window.rootViewController = HomeViewController()
-        window.makeKeyAndVisible()
+        let router = DemoRootBuilder(dependency: DemoRootComponent()).build()
+        router.listener = self
+        self.launchRouter = router
+        router.launch(from: window)
         return true
     }
+    
+}
+
+extension AppDelegate: DemoRootRouterListener, HomeListener {
+    
+    func demoRootRouterDidBecomeActive() {
+        launchRouter?.attach(execute: { viewController in
+            let router = HomeBuilder(dependency: HomeRootComponent()).build(withListener: self)
+            viewController.present(NavigationControllable(viewControllable: router.viewControllable), animated: true, isFullScreen: true)
+            launchRouter?.attachChild(router)
+        })
+    }
+    
+}
+
+final class HomeRootComponent: HomeDependency {
+    
+    let homeUseCase: HomeUseCaseInterface = HomeUseCase(
+        repository: HomeRepository(
+            session: NetworkProvider(
+                session: URLSession.shared
+            )
+        )
+    )
+    
 }

--- a/client/Targets/Presentation/My/Demo/Project.swift
+++ b/client/Targets/Presentation/My/Demo/Project.swift
@@ -7,5 +7,7 @@ let project = Project.demo(
     dependencies: [
         .Target.Presentation.My.Interfaces,
         .Target.Presentation.My.Implementations,
+        .Target.Data.Repositories,
+        .Target.Domain.UseCases
     ]
 )

--- a/client/Targets/Presentation/My/Demo/Sources/AppDelegate.swift
+++ b/client/Targets/Presentation/My/Demo/Sources/AppDelegate.swift
@@ -1,17 +1,46 @@
 import UIKit
+import MyInterfaces
 import MyImplementations
+import ModernRIBs
+import CoreKit
+import NetworkAPIKit
+import BasePresentation
+import DomainInterfaces
+import DomainUseCases
+import DataRepositories
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    
     var window: UIWindow?
+    
+    private var launchRouter: DemoRootRouter?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window
-        let viewController = MyPageViewController()
-        viewController.view.backgroundColor = .systemPink
-        window.rootViewController = viewController
-        window.makeKeyAndVisible()
+        let router = DemoRootBuilder(dependency: DemoRootComponent()).build()
+        router.listener = self
+        self.launchRouter = router
+        router.launch(from: window)
         return true
     }
+    
+}
+
+extension AppDelegate: DemoRootRouterListener, MyPageListener {
+    
+    func demoRootRouterDidBecomeActive() {
+        launchRouter?.attach(execute: { viewController in
+            let router = MyPageBuilder(dependency: MyPageRootComponent()).build(withListener: self)
+            viewController.present(NavigationControllable(viewControllable: router.viewControllable), animated: true, isFullScreen: true)
+            launchRouter?.attachChild(router)
+        })
+    }
+    
+}
+
+final class MyPageRootComponent: MyPageDependency {
+    
+    
 }

--- a/client/Targets/Presentation/Search/Demo/Project.swift
+++ b/client/Targets/Presentation/Search/Demo/Project.swift
@@ -7,5 +7,7 @@ let project = Project.demo(
     dependencies: [
         .Target.Presentation.Search.Interfaces,
         .Target.Presentation.Search.Implementations,
+        .Target.Data.Repositories,
+        .Target.Domain.UseCases
     ]
 )

--- a/client/Targets/Presentation/Story/Demo/Project.swift
+++ b/client/Targets/Presentation/Story/Demo/Project.swift
@@ -7,5 +7,7 @@ let project = Project.demo(
     dependencies: [
         .Target.Presentation.Story.Interfaces,
         .Target.Presentation.Story.Implementations,
+        .Target.Data.Repositories,
+        .Target.Domain.UseCases
     ]
 )

--- a/client/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/client/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -175,11 +175,19 @@ extension Project {
                 "UILaunchStoryboardName": "LaunchScreen",
                 "LSSupportsOpeningDocumentsInPlace": true,
                 "UIFileSharingEnabled": true,
+                "NaverLoginConsumerKey": "$(NAVER_LOGIN_CONSUMER_KEY)",
+                "NaverLoginConsumerSecret": "$(NAVER_LOGIN_CONSUMER_SECRET)",
+                "NaverMapClientID": "$(NAVER_MAP_CLIENT_ID)",
+                "NaverMapSecret": "$(NAVER_MAP_SECRET)",
+                "BaseURL": "$(BASE_URL)"
             ]),
             sources: ["Sources/**"],
             resources: ["Resources/**"],
             dependencies: dependencies,
-            settings: .settings(defaultSettings: .recommended)
+            settings: .settings(configurations: [
+                .debug(name: .debug, xcconfig: XCConfig.secret),
+                .release(name: .release, xcconfig: XCConfig.secret),
+            ])
         )
         targets.append(target)
         

--- a/client/Tuist/Stencils/AppDelegate.stencil
+++ b/client/Tuist/Stencils/AppDelegate.stencil
@@ -1,16 +1,37 @@
 import UIKit
+import ModernRIBs
+import CoreKit
+import NetworkAPIKit
+import BasePresentation
+import DomainInterfaces
+import DomainUseCases
+import DataRepositories
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    
     var window: UIWindow?
+    
+    private var launchRouter: DemoRootRouter?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
         self.window = window
-        let viewController = UIViewController()
-        viewController.view.backgroundColor = .systemPink
-        window.rootViewController = viewController
-        window.makeKeyAndVisible()
+        let router = DemoRootBuilder(dependency: DemoRootComponent()).build()
+        router.listener = self
+        self.launchRouter = router
+        router.launch(from: window)
         return true
     }
+    
+}
+
+extension AppDelegate: DemoRootRouterListener {
+    
+    func demoRootRouterDidBecomeActive() {
+        launchRouter?.attach(execute: { viewController in
+        // 라우팅 로직 추가
+        })
+    }
+    
 }

--- a/client/Tuist/Stencils/Project-demo.stencil
+++ b/client/Tuist/Stencils/Project-demo.stencil
@@ -7,5 +7,7 @@ let project = Project.demo(
     dependencies: [
         .Target.Presentation.{{ name }}.Interfaces,
         .Target.Presentation.{{ name }}.Implementations,
+        .Target.Data.Repositories,
+        .Target.Domain.UseCases
     ]
 )


### PR DESCRIPTION
## 🌁 배경
* close #253 
* 기존 데모앱은 단순히 ViewController의 UI 로직만을 작업했습니다.
* 비즈니스 로직까지 작업할 수 있도록 Demo Root 리블렛을 추가했습니다.

## ✅ 수정 내역
* Demo Root 리블렛 추가
* Demo 템플릿 수정
* Demo 의존성 변경
* Home/MyPage Demo 설정

## ⚙️ 테스트 방법
### 마이페이지 데모앱 기준
* 기존에 데모앱을 생성하는 방식대로 생성합니다.
  * `tuist generate --path Targets/Presentation/My/Demo` 
* 앱 델리게이트 값을 설정합니다.
```swift
import UIKit
import MyInterfaces // 해당 모듈의 인터페이스
import MyImplementations // 해당 모듈의 구현체
import ModernRIBs
import CoreKit
import NetworkAPIKit
import BasePresentation
import DomainInterfaces
import DomainUseCases
import DataRepositories

@main
class AppDelegate: UIResponder, UIApplicationDelegate {
    
    var window: UIWindow?
    
    private var launchRouter: DemoRootRouter?

    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
        let window = UIWindow(frame: UIScreen.main.bounds)
        self.window = window
        let router = DemoRootBuilder(dependency: DemoRootComponent()).build()
        router.listener = self
        self.launchRouter = router
        router.launch(from: window)
        return true
    }
    
}

extension AppDelegate: DemoRootRouterListener, MyPageListener {
    
    func demoRootRouterDidBecomeActive() {
        launchRouter?.attach(execute: { viewController in
            // 여기 위치에서 시작할 리블렛을 설정해주면 됩니다.
            let router = MyPageBuilder(dependency: MyPageRootComponent()).build(withListener: self)
            viewController.present(NavigationControllable(viewControllable: router.viewControllable), animated: true, isFullScreen: true)
            launchRouter?.attachChild(router)
        })
    }
    
}

final class MyPageRootComponent: MyPageDependency {}
```

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/2d2730bd-d47e-4093-9814-f79a664c81b8


