### PR TITLE
TaskCancelBag 추가

### DIFF
--- a/client/Targets/Core/CoreKit/Sources/TaskUtil/AnyCancellableTask.swift
+++ b/client/Targets/Core/CoreKit/Sources/TaskUtil/AnyCancellableTask.swift
@@ -1,0 +1,15 @@
+//
+//  AnyCancellableTask.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 11/23/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public protocol AnyCancellableTask {
+    func cancel()
+}
+
+extension Task: AnyCancellableTask {}

--- a/client/Targets/Core/CoreKit/Sources/TaskUtil/CancelBag.swift
+++ b/client/Targets/Core/CoreKit/Sources/TaskUtil/CancelBag.swift
@@ -1,0 +1,37 @@
+//
+//  CancelBag.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 11/23/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+public final class CancelBag {
+    
+    private var cancellables: [AnyCancellableTask] = []
+    
+    public init() {}
+    
+    public func store(task: AnyCancellableTask) {
+        cancellables.append(task)
+    }
+    
+    public func cancel() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+    }
+    
+    deinit { cancel() }
+    
+}
+
+extension Task {
+    
+    public func store(in bag: CancelBag) {
+        bag.store(task: self)
+    }
+    
+}


### PR DESCRIPTION
## 🌁 배경
* close #257 
* Task (async/await)을 취소하기 위해 추가했습니다.

## ✅ 수정 내역
* CancelBag 추가

## ⚙️ 테스트 방법
1. CoreKit import
2. CancelBag() 생성
3. Task {}.store(in: bag)
```swift
import CoreKit

private let cancelBag = CancelBag()

func fetchHotPlace() {
    Task {
        await dependency.hotPlaceUseCase.fetchHotPlace()
            .onSuccess(on: .main, with: self) { this, stories in
                this.performAfterFetchingHotPlace(stories: stories)
            }
            .onFailure { error in
                Log.make(message: error.localizedDescription, log: .interactor)
            }
    }.store(in: cancelBag)
}
```

## 📕 리뷰 노트
* [참고](https://minsone.github.io/swift-concurrency-AnyCancelTaskBag)
