### PR TITLE
Invalid Token 로그아웃 추가, Alert Sugar 추가

### DIFF
--- a/client/Targets/Core/CoreKit/Sources/Alert/ViewControllable+Alert.swift
+++ b/client/Targets/Core/CoreKit/Sources/Alert/ViewControllable+Alert.swift
@@ -1,0 +1,24 @@
+//
+//  ViewControllable+Alert.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 11/23/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import FoundationKit
+import ModernRIBs
+
+public extension ViewControllable {
+    
+    func present(type: AlertType, okAction: @escaping (() -> Void)) {
+        uiviewController.presentAlert(
+            title: type.title,
+            message: type.message,
+            okAction: okAction,
+            isCancelButtonEnabled: type.isCancellable
+        )
+    }
+    
+}

--- a/client/Targets/Core/FoundationKit/Sources/Alert/AlertPresentable.swift
+++ b/client/Targets/Core/FoundationKit/Sources/Alert/AlertPresentable.swift
@@ -1,0 +1,44 @@
+//
+//  AlertPresentable.swift
+//  FoundationKit
+//
+//  Created by 홍성준 on 11/23/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+
+public protocol AlertPresentable {
+    func presentAlert(
+        title: String,
+        message: String,
+        okAction: @escaping (() -> Void),
+        isCancelButtonEnabled: Bool
+    )
+}
+
+public extension AlertPresentable where Self: UIViewController {
+    
+    func presentAlert(
+        title: String,
+        message: String,
+        okAction: @escaping (() -> Void),
+        isCancelButtonEnabled: Bool = false
+    ) {
+        let alert = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+        )
+        alert.addAction(.init(title: "확인", style: .default, handler: { _ in
+            okAction()
+        }))
+        if isCancelButtonEnabled {
+            alert.addAction(.init(title: "취소", style: .cancel))
+        }
+        present(alert, animated: true)
+    }
+    
+}
+
+extension UIViewController: AlertPresentable {}

--- a/client/Targets/Core/FoundationKit/Sources/Alert/AlertType.swift
+++ b/client/Targets/Core/FoundationKit/Sources/Alert/AlertType.swift
@@ -1,0 +1,45 @@
+//
+//  AlertType.swift
+//  FoundationKit
+//
+//  Created by 홍성준 on 11/23/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public enum AlertType {
+    
+    case invalidToken
+    case signOut
+    case resign
+    
+}
+
+extension AlertType {
+    
+    public var title: String {
+        switch self {
+        case .invalidToken: return "올바르지 않은 회원 정보"
+        case .signOut: return "로그아웃"
+        case .resign: return "회원 탈퇴"
+        }
+    }
+    
+    public var message: String {
+        switch self {
+        case .invalidToken: return "회원 정보가 올바르지 않아요. 확인 버튼을 누르면 로그인 화면으로 이동해요"
+        case .signOut: return "로그아웃을 하게 되면 로그인 화면으로 이동해요"
+        case .resign: return "탈퇴하시면 기존의 정보는 모두 제거돼요. 정말 탈퇴 하실건가요?"
+        }
+    }
+    
+    public var isCancellable: Bool {
+        switch self {
+        case .invalidToken: return false
+        case .signOut: return true
+        case .resign: return true
+        }
+    }
+    
+}

--- a/client/Targets/Core/FoundationKit/Sources/Alert/SignOutService+Alert.swift
+++ b/client/Targets/Core/FoundationKit/Sources/Alert/SignOutService+Alert.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension SignoutService {
     
-    static var keyWindow: UIWindow? {
+    var keyWindow: UIWindow? {
         return UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .flatMap(\.windows)
@@ -19,7 +19,7 @@ extension SignoutService {
     }
     
     func presentAlert(type: AlertType, action: @escaping (() -> Void)) {
-        SignoutService.keyWindow?.rootViewController?
+        keyWindow?.rootViewController?
             .presentAlert(
                 title: type.title,
                 message: type.message,

--- a/client/Targets/Core/FoundationKit/Sources/Alert/SignOutService+Alert.swift
+++ b/client/Targets/Core/FoundationKit/Sources/Alert/SignOutService+Alert.swift
@@ -1,0 +1,31 @@
+//
+//  SignOutService+Alert.swift
+//  FoundationKit
+//
+//  Created by 홍성준 on 11/23/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+
+extension SignoutService {
+    
+    static var keyWindow: UIWindow? {
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .filter(\.isKeyWindow)
+            .first
+    }
+    
+    func presentAlert(type: AlertType, action: @escaping (() -> Void)) {
+        SignoutService.keyWindow?.rootViewController?
+            .presentAlert(
+                title: type.title,
+                message: type.message,
+                okAction: action,
+                isCancelButtonEnabled: type.isCancellable
+            )
+    }
+    
+}

--- a/client/Targets/Core/FoundationKit/Sources/Alert/SignOutService+Alert.swift
+++ b/client/Targets/Core/FoundationKit/Sources/Alert/SignOutService+Alert.swift
@@ -19,13 +19,15 @@ extension SignoutService {
     }
     
     func presentAlert(type: AlertType, action: @escaping (() -> Void)) {
-        keyWindow?.rootViewController?
-            .presentAlert(
-                title: type.title,
-                message: type.message,
-                okAction: action,
-                isCancelButtonEnabled: type.isCancellable
-            )
+        DispatchQueue.main.async { [weak self] in
+            self?.keyWindow?.rootViewController?
+                .presentAlert(
+                    title: type.title,
+                    message: type.message,
+                    okAction: action,
+                    isCancelButtonEnabled: type.isCancellable
+                )
+        }
     }
     
 }

--- a/client/Targets/Core/FoundationKit/Sources/User/SignOutService.swift
+++ b/client/Targets/Core/FoundationKit/Sources/User/SignOutService.swift
@@ -18,6 +18,7 @@ public protocol SignOutServiceInterface: AnyObject {
 public protocol SignOutRequestServiceInterface: AnyObject {
     
     func signOut()
+    func singOut(type: AlertType)
     
 }
 
@@ -36,6 +37,12 @@ public final class SignoutService: SignOutServiceInterface, SignOutRequestServic
     public func signOut() {
         SecretManager.remove(type: .accessToken)
         signOutCompletedSubject.send(true)
+    }
+    
+    public func singOut(type: AlertType) {
+        presentAlert(type: type) { [weak self] in
+            self?.signOut()
+        }
     }
     
 }

--- a/client/Targets/Core/FoundationKit/Sources/User/SignOutService.swift
+++ b/client/Targets/Core/FoundationKit/Sources/User/SignOutService.swift
@@ -18,7 +18,7 @@ public protocol SignOutServiceInterface: AnyObject {
 public protocol SignOutRequestServiceInterface: AnyObject {
     
     func signOut()
-    func singOut(type: AlertType)
+    func signOut(type: AlertType)
     
 }
 
@@ -39,7 +39,7 @@ public final class SignoutService: SignOutServiceInterface, SignOutRequestServic
         signOutCompletedSubject.send(true)
     }
     
-    public func singOut(type: AlertType) {
+    public func signOut(type: AlertType) {
         presentAlert(type: type) { [weak self] in
             self?.signOut()
         }

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkErrorCode.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkErrorCode.swift
@@ -1,0 +1,16 @@
+//
+//  NetworkErrorCode.swift
+//  NetworkAPIKit
+//
+//  Created by 홍성준 on 11/23/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public enum NetworkErrorCode: Int {
+    
+    case invalidToken = 498
+    case internalServcerError = 500
+    
+}

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkProvider.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkProvider.swift
@@ -124,7 +124,7 @@ public final class NetworkProvider: Network {
         
         switch errorCode {
         case .invalidToken:
-            SignoutService.shared.singOut(type: .invalidToken)
+            SignoutService.shared.signOut(type: .invalidToken)
             
         default:
             return

--- a/client/Targets/Presentation/My/Implementations/Sources/Setting/SettingInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/Setting/SettingInteractor.swift
@@ -64,7 +64,7 @@ final class SettingInteractor: PresentableInteractor<SettingPresentable>, Settin
     }
     
     func didTapSignOut() {
-        dependency.signOutRequestService.signOut()
+        dependency.signOutRequestService.signOut(type: .signOut)
     }
     
 }


### PR DESCRIPTION
## 🌁 배경
* close #212 

## ✅ 수정 내역
* Alert Sugar 코드 추가
* Invalid Token일 경우 로그아웃 기능 추가

## ⚙️ 테스트 방법
* NetworkProvider에 있는 상태 코드를 498로 변경하면 됩니다.
```swift
private func interceptResponseIfNeeded(_ response: URLResponse) {
    guard let httpResponse = response as? HTTPURLResponse,
          let errorCode = NetworkErrorCode(rawValue: httpResponse.statusCode) // 여기에 상태코드 대신 498로 변경
    else {
        return
    }
    
    switch errorCode {
    case .invalidToken:
        SignoutService.shared.signOut(type: .invalidToken)
        
    default:
        return
    }
}
```

## 📕 리뷰 노트
* FoundationKit에 Alert에 대한 정의가 있습니다.
* ViewControllable도 바로 동작할 수 있도록 만들어 놔서 Interactor에서 바로 사용할 수 있습니다.
```swift
// SettingInteractor.swift
func didTapResign() {
    router?.viewControllable.present(type: .resign, okAction: {
        print("탈퇴해주세요")
    })
}
```

## 🎇 스크린샷

https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/d331c549-dad8-42e5-8238-6f3fc8527a70


