### PR TITLE
Network 토큰 요청 방식 변경

### DIFF
--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkHeader.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkHeader.swift
@@ -23,8 +23,8 @@ public class NetworkHeader {
     }
     
     @discardableResult
-    public func accessToken(_ value: String) -> Self {
-        headers["accessToken"] = value
+    public func authorization(_ value: String, usingBearer: Bool = true) -> Self {
+        headers["Authorization"] = usingBearer ? "Bearer \(value)" : value
         return self
     }
     

--- a/client/Targets/Data/Network/Base/Sources/NetworkHeader+Authorized.swift
+++ b/client/Targets/Data/Network/Base/Sources/NetworkHeader+Authorized.swift
@@ -21,7 +21,7 @@ public extension NetworkHeader {
     
     static var authorized: NetworkHeader {
         guard let token = token else { return .default }
-        return .default.accessToken(token)
+        return .default.authorization(token)
     }
     
 }


### PR DESCRIPTION
## 🌁 배경
* close #329 
* 서버쪽 JWT 인증 방식이 변경되어 수정하였습니다.
  * accessToken 값에서 Authorization 으로 Key값 변경 및 Bearer 추가
* [히스토리](https://boostcampwm-8-me.slack.com/archives/C060U825MJM/p1701057223408379)

## ✅ 수정 내역
* Network 토큰 요청 방식 변경
