### PR TITLE
ImageSelector가 live photo를 지원하도록 수정

### DIFF
--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
@@ -22,6 +22,7 @@ final class ImageSelector: UIView {
 
     enum Constant {
         static let transparentBlack: UIColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)
+        static let buttonWidthHeight: CGFloat = 44
     }
     weak var delegate: ImageSelectorDelegate?
     weak var presenterDelegate: ImageSelectorPickerPresenterDelegate?
@@ -96,8 +97,8 @@ private extension ImageSelector {
     
     private func setupPlusImageView() {
         NSLayoutConstraint.activate([
-            plusImageView.widthAnchor.constraint(equalToConstant: 25),
-            plusImageView.heightAnchor.constraint(equalToConstant: 25),
+            plusImageView.widthAnchor.constraint(equalToConstant: Constant.buttonWidthHeight),
+            plusImageView.heightAnchor.constraint(equalToConstant: Constant.buttonWidthHeight),
             plusImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
             plusImageView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
@@ -105,10 +106,10 @@ private extension ImageSelector {
     
     private func setupXImageView() {
         NSLayoutConstraint.activate([
-            xImageView.widthAnchor.constraint(equalToConstant: 14),
-            xImageView.heightAnchor.constraint(equalToConstant: 14),
-            xImageView.topAnchor.constraint(equalTo: topAnchor, constant: 5),
-            xImageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5)
+            xImageView.widthAnchor.constraint(equalToConstant: Constant.buttonWidthHeight),
+            xImageView.heightAnchor.constraint(equalToConstant: Constant.buttonWidthHeight),
+            xImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            xImageView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
     

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
@@ -113,6 +113,10 @@ private extension ImageSelector {
         ])
     }
     
+}
+
+private extension ImageSelector {
+    
     @objc func addImageDidTap() {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
         configuration.selectionLimit = 1
@@ -126,6 +130,13 @@ private extension ImageSelector {
     @objc func removeImageDidTap() {
         delegate?.imageDidRemove(from: self)
     }
+    
+    func changeToRemoveButton() {
+        plusImageView.removeFromSuperview()
+        addSubview(xImageView)
+        setupXImageView()
+        delegate?.imageDidAdd()
+    }
 }
 
 extension ImageSelector: PHPickerViewControllerDelegate {
@@ -138,12 +149,9 @@ extension ImageSelector: PHPickerViewControllerDelegate {
             
             itemProvider.loadObject(ofClass: UIImage.self) { image, _ in
                 DispatchQueue.main.async { [weak self] in
-                    guard let image = image as? UIImage, let xImageView = self?.xImageView else { return }
-                    self?.imageView.image = image
-                    self?.plusImageView.removeFromSuperview()
-                    self?.addSubview(xImageView)
-                    self?.setupXImageView()
-                    self?.delegate?.imageDidAdd()
+                    guard let image = image as? UIImage, let self else { return }
+                    imageView.image = image
+                    changeToRemoveButton()
                 }
             }
             return
@@ -160,11 +168,8 @@ extension ImageSelector: PHPickerViewControllerDelegate {
                 }, completionHandler: { error in
                     DispatchQueue.main.async { [weak self] in
                         guard let self else { return }
-                        self.imageView.image = UIImage(data: imageData as Data)
-                        self.plusImageView.removeFromSuperview()
-                        self.addSubview(xImageView)
-                        self.setupXImageView()
-                        self.delegate?.imageDidAdd()
+                        imageView.image = UIImage(data: imageData as Data)
+                        changeToRemoveButton()
                     }
                 })
             }


### PR DESCRIPTION
## 🌁 배경
* #340 

## ✅ 수정 내역
* PHPicker에서 사진만 보이도록 filter 적용
* Live Photo를 선택할 수 있도록 수정
* 사진 추가/삭제 버튼 크기 및 위치 수정

##🎇 스크린샷
![image](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/26802673-9465-4c65-a7a3-d78a290d8810)

