### PR TITLE
검색 스토리상세 구현

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
@@ -11,9 +11,9 @@ import ModernRIBs
 import CoreKit
 import AuthInterfaces
 import HomeInterfaces
-import SearchImplementations
 import StoryInterfaces
 import MyInterfaces
+import SearchInterfaces
 
 protocol AppRootInteractable: Interactable,
                               SignInListener,

--- a/client/Targets/Data/Network/Search/Sources/DTO/SearchRecommendResponseDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/SearchRecommendResponseDTO.swift
@@ -10,14 +10,14 @@ import Foundation
 
 public struct SearchRecommendResponseDTO: Decodable {
     
-    public let recommendTexts: [String]
+    public let recommends: [String]
     
 }
 
 public extension SearchRecommendResponseDTO {
     
     func toDmain() -> [String] {
-        recommendTexts
+        recommends
     }
     
 }

--- a/client/Targets/Data/Repositories/Sources/SearchRepository.swift
+++ b/client/Targets/Data/Repositories/Sources/SearchRepository.swift
@@ -45,8 +45,8 @@ public final class SearchRepository: SearchRepositoryInterface {
     // TODO: Combine으로 ??
     public func fetchRecommendText(searchText: String) async -> Result<[String], Error> {
         let target = SearchAPI.recommend(searchText: searchText)
-        let request: Result<[String], Error> = await session.request(target)
-        return request
+        let request: Result<SearchRecommendResponseDTO, Error> = await session.request(target)
+        return request.map { $0.toDmain() }
     }
     
     public func fetchRecentSearches() -> [String] {

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchBuilder.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchBuilder.swift
@@ -8,6 +8,7 @@
 
 import ModernRIBs
 import HomeInterfaces
+import SearchInterfaces
 import StoryInterfaces
 import DomainInterfaces
 
@@ -41,10 +42,6 @@ final class SearchRouterComponent: SearchRouterDependency {
         self.storyDeatilBuilder = component.storyDeatilBuilder
     }
     
-}
-
-public protocol SearchBuildable: Buildable {
-    func build(withListener listener: SearchListener) -> ViewableRouting
 }
 
 public final class SearchBuilder: Builder<SearchDependency>, SearchBuildable {

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -9,6 +9,7 @@
 import ModernRIBs
 import DomainEntities
 import DomainInterfaces
+import SearchInterfaces
 import BasePresentation
 
 protocol SearchRouting: ViewableRouting {
@@ -28,8 +29,6 @@ protocol SearchPresentable: Presentable {
     func updateMarkers(places: [Place])
     func removeAllMarker()
 }
-
-public protocol SearchListener: AnyObject { }
 
 protocol SearchInteractorDependency: AnyObject {
     var searchUseCase: SearchUseCaseInterface { get }
@@ -126,6 +125,10 @@ final class SearchInteractor: PresentableInteractor<SearchPresentable>,
                     this.presenter.updateMarkers(places: places)
                 }
         }
+    }
+    
+    func searchAfterStoryViewDidTap(storyId: Int) {
+        router?.attachStoryDetail(storyID: storyId)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterDashboardInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterDashboardInteractor.swift
@@ -27,6 +27,9 @@ protocol SearchAfterDashboardPresentable: Presentable {
 
 protocol SearchAfterDashboardListener: AnyObject {
     var endEditingSearchTextPublisher: AnyPublisher<String, Never> { get }
+    
+    func searchAfterHeaderViewSeeAllViewDidTap(searchText: String)
+    func searchAfterStoryViewDidTap(storyId: Int)
 }
 
 protocol SearchAfterDashboardInteractorDependency: AnyObject {
@@ -47,6 +50,7 @@ final class SearchAfterDashboardInteractor: PresentableInteractor<SearchAfterDas
     private var searchResultUsersSubject: PassthroughSubject<[SearchUser], Never> = .init()
     private var cancellables: Set<AnyCancellable> = []
     private var cancelTaskBag: CancelBag = .init()
+    private var searchText: String = ""
     
     init(
         presenter: SearchAfterDashboardPresentable,
@@ -65,6 +69,7 @@ final class SearchAfterDashboardInteractor: PresentableInteractor<SearchAfterDas
         listener?.endEditingSearchTextPublisher
             .sink { [weak self] searchText in
                 guard let self else { return }
+                self.searchText = searchText
                 Task {
                     await self.dependency.searhResultSearchAfterUseCase
                         .fetchResult(searchText: searchText)
@@ -83,6 +88,14 @@ final class SearchAfterDashboardInteractor: PresentableInteractor<SearchAfterDas
         super.willResignActive()
         router?.detachSearchAfterStoryDashboard()
         router?.detachSearchAfterUserDashboard()
+    }
+    
+    func searchAfterHeaderViewSeeAllViewDidTap() {
+        listener?.searchAfterHeaderViewSeeAllViewDidTap(searchText: searchText)
+    }
+    
+    func searchAfterStoryViewDidTap(storyId: Int) {
+        listener?.searchAfterStoryViewDidTap(storyId: storyId)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterStoryDashboard/SearchAfterStoryDashboardInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterStoryDashboard/SearchAfterStoryDashboardInteractor.swift
@@ -24,6 +24,9 @@ protocol SearchAfterStoryDashboardPresentable: Presentable {
 
 protocol SearchAfterStoryDashboardListener: AnyObject { 
     var searchResultStoriesPublisher: AnyPublisher<[SearchStory], Never> { get }
+    
+    func searchAfterHeaderViewSeeAllViewDidTap()
+    func searchAfterStoryViewDidTap(storyId: Int)
 }
 
 final class SearchAfterStoryDashboardInteractor: PresentableInteractor<SearchAfterStoryDashboardPresentable>, SearchAfterStoryDashboardInteractable, SearchAfterStoryDashboardPresentableListener {
@@ -53,6 +56,10 @@ final class SearchAfterStoryDashboardInteractor: PresentableInteractor<SearchAft
     }
     
     func searchAfterHeaderViewSeeAllViewDidTap() {
-        // TODO: 성준님이 작성하신 뷰 연결
+        listener?.searchAfterHeaderViewSeeAllViewDidTap()
+    }
+    
+    func searchAfterStoryViewDidTap(storyId: Int) {
+        listener?.searchAfterStoryViewDidTap(storyId: storyId)
     }
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterStoryDashboard/SearchAfterStoryDashboardViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterStoryDashboard/SearchAfterStoryDashboardViewController.swift
@@ -15,6 +15,7 @@ import DomainEntities
 
 protocol SearchAfterStoryDashboardPresentableListener: AnyObject {
     func searchAfterHeaderViewSeeAllViewDidTap()
+    func searchAfterStoryViewDidTap(storyId: Int)
 }
 
 final class SearchAfterStoryDashboardViewController: UIViewController, SearchAfterStoryDashboardPresentable, SearchAfterStoryDashboardViewControllable {
@@ -85,13 +86,14 @@ final class SearchAfterStoryDashboardViewController: UIViewController, SearchAft
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         let isEmpty = models.isEmpty
         headerView.isHiddenSeeAllView(isEmpty)
-        emptyView.isHidden = !isEmpty
-        scrollView.isHidden = isEmpty
         models.forEach { model in
             let contentView = SearchAfterStoryView()
             contentView.setup(model: model)
+            contentView.delegate = self
             self.stackView.addArrangedSubview(contentView)
         }
+        emptyView.isHidden = !isEmpty
+        scrollView.isHidden = isEmpty
     }
     
 }
@@ -129,6 +131,15 @@ extension SearchAfterStoryDashboardViewController: SearchAfterHeaderViewDelegate
     
     func searchAfterHeaderViewSeeAllViewDidTap() {
         listener?.searchAfterHeaderViewSeeAllViewDidTap()
+    }
+    
+}
+
+
+extension SearchAfterStoryDashboardViewController: SearchAfterStoryViewDelegate {
+    
+    func searchAfterStoryViewDidTap(storyId: Int) {
+        listener?.searchAfterStoryViewDidTap(storyId: storyId)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterStoryDashboard/Views/SearchAfterStoryView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterStoryDashboard/Views/SearchAfterStoryView.swift
@@ -12,6 +12,10 @@ import DesignKit
 import DomainEntities
 import BasePresentation
 
+protocol SearchAfterStoryViewDelegate: AnyObject {
+    func searchAfterStoryViewDidTap(storyId: Int)
+}
+
 final class SearchAfterStoryView: UIView {
     
     private enum Constant {
@@ -25,6 +29,8 @@ final class SearchAfterStoryView: UIView {
             static let spacing: CGFloat = 5
         }
     }
+    
+    weak var delegate: SearchAfterStoryViewDelegate?
     
     private var storyId: Int?
     
@@ -75,11 +81,13 @@ final class SearchAfterStoryView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setupConfiguration()
         setupViews()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        setupConfiguration()
         setupViews()
     }
     
@@ -109,6 +117,23 @@ private extension SearchAfterStoryView {
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.traillingOffset),
             stackView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
+    }
+    
+    func setupConfiguration() {
+        let tapGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(searchAfterStoryViewDidTap)
+        )
+        addGestureRecognizer(tapGesture)
+    }
+    
+}
+
+private extension SearchAfterStoryView {
+    
+    @objc func searchAfterStoryViewDidTap() {
+        guard let storyId else { return }
+        delegate?.searchAfterStoryViewDidTap(storyId: storyId)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterUserDashboard/SearchAfterUserDashboardViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterUserDashboard/SearchAfterUserDashboardViewController.swift
@@ -52,7 +52,6 @@ final class SearchAfterUserDashboardViewController: UIViewController, SearchAfte
             title: Constant.EmptyView.title,
             subtitle: Constant.EmptyView.subTitle)
         )
-        emptyView.isHidden = true
         emptyView.translatesAutoresizingMaskIntoConstraints = false
         return emptyView
     }()
@@ -85,14 +84,13 @@ final class SearchAfterUserDashboardViewController: UIViewController, SearchAfte
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         let isEmpty = models.isEmpty
         headerView.isHiddenSeeAllView(isEmpty)
-        emptyView.isHidden = !isEmpty
-        scrollView.isHidden = isEmpty
         models.forEach { model in
             let contentView = SearchAfterUserView()
             contentView.setup(model: model)
             self.stackView.addArrangedSubview(contentView)
         }
-        
+        emptyView.isHidden = !isEmpty
+        scrollView.isHidden = isEmpty
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchBeforeDashboard/SearchBeforeCategoryDashboard/Views/SearchBeforeCategoryView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchBeforeDashboard/SearchBeforeCategoryDashboard/Views/SearchBeforeCategoryView.swift
@@ -40,7 +40,7 @@ final class SearchBeforeCategoryView: UIView {
     
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.font = .captionBold
+        label.font = .captionRegular
         label.text = "내용"
         label.numberOfLines = 0
         label.textColor = .hpGray1
@@ -89,7 +89,7 @@ private extension SearchBeforeCategoryView {
         clipsToBounds = true
         layer.cornerRadius = Constants.cornerRadiusMedium
         layer.borderWidth = 1
-        layer.borderColor = UIColor.lightGray.cgColor
+        layer.borderColor = UIColor.hpGray3.cgColor
         
         let tapGesture = UITapGestureRecognizer(
             target: self,

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchBeforeDashboard/SearchBeforeRecentSearchesDashboard/SearchBeforeRecentSearchesDashboardInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchBeforeDashboard/SearchBeforeRecentSearchesDashboard/SearchBeforeRecentSearchesDashboardInteractor.swift
@@ -56,7 +56,6 @@ final class SearchBeforeRecentSearchesDashboardInteractor: PresentableInteractor
         listener?.endEditingSearchTextPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] searchText in
-                Log.make(message: "\(String(describing: self)), searchText: \(searchText)", log: .default)
                 guard let self,
                       let text = self.dependecy.searchBeforeRecentSearchesUsecase.appendRecentSearch(searchText: searchText) else { return }
                 self.presenter.append(model: text)

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchBeforeDashboard/SearchBeforeRecentSearchesDashboard/Views/SearchBeforeRecentSearchesEmptyView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchBeforeDashboard/SearchBeforeRecentSearchesDashboard/Views/SearchBeforeRecentSearchesEmptyView.swift
@@ -11,6 +11,13 @@ import DesignKit
 
 final class SearchBeforeRecentSearchesEmptyView: UIView {
     
+    private enum Constant {
+        static let topOffset: CGFloat = 10
+        static let bottomOffset: CGFloat = -topOffset
+        static let leadingOffset: CGFloat = 10
+        static let trailingOffset: CGFloat = -leadingOffset
+    }
+    
     private let titleLabel: UILabel = {
        let label = UILabel()
         label.font = .bodyRegular
@@ -38,9 +45,6 @@ private extension SearchBeforeRecentSearchesEmptyView {
     
     func setupViews() {
         clipsToBounds = true
-        layer.cornerRadius = Constants.cornerRadiusMedium
-        layer.borderWidth = 1
-        layer.borderColor = UIColor.lightGray.cgColor
         
         addSubview(titleLabel)
         

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchBeforeDashboard/SearchBeforeRecentSearchesDashboard/Views/SearchBeforeRecentSearchesView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchBeforeDashboard/SearchBeforeRecentSearchesDashboard/Views/SearchBeforeRecentSearchesView.swift
@@ -72,8 +72,10 @@ private extension SearchBeforeRecentSearchesView {
     
     func setupConfiguration() {
         clipsToBounds = true
-        backgroundColor = .hpGray3
+        backgroundColor = .hpGray5
         layer.cornerRadius = Constants.cornerRadiusSmall
+        layer.borderWidth = 1
+        layer.borderColor = UIColor.hpGray3.cgColor
         
         let tapGesture = UITapGestureRecognizer(
             target: self,

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchResultInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchResultInteractor.swift
@@ -27,6 +27,11 @@ protocol SearchResultRouting: ViewableRouting {
     func detachSearchAfterDashboard()
     func showSearchAfterDashboard()
     func hideSearchAfterDashboard()
+    
+    func attachStoryDetail(storyId: Int)
+    func detachStroyDetail()
+    func attachStroySeeAll(searchText: String)
+    func detailStroySeeAll()
 }
 
 protocol SearchResultPresentable: Presentable {
@@ -37,10 +42,11 @@ protocol SearchResultPresentable: Presentable {
 
 protocol SearchResultListener: AnyObject { 
     func detachSearchResult()
+    func searchAfterStoryViewDidTap(storyId: Int)
 }
 
-final class SearchResultInteractor: PresentableInteractor<SearchResultPresentable>, SearchResultInteractable, SearchResultPresentableListener {    
-
+final class SearchResultInteractor: PresentableInteractor<SearchResultPresentable>, SearchResultInteractable, SearchResultPresentableListener {
+    
     weak var router: SearchResultRouting?
     weak var listener: SearchResultListener?
     
@@ -108,6 +114,20 @@ extension SearchResultInteractor {
         router?.hideSearchBeforeDashboard()
         router?.hideSearchingDashboard()
         router?.showSearchAfterDashboard()
+    }
+    
+}
+
+
+// MARK: SearchAfter
+extension SearchResultInteractor {
+    
+    func searchAfterHeaderViewSeeAllViewDidTap(searchText: String) {
+        router?.attachStroySeeAll(searchText: searchText)
+    }
+    
+    func searchAfterStoryViewDidTap(storyId: Int) {
+        listener?.searchAfterStoryViewDidTap(storyId: storyId)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchResultRouter.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchResultRouter.swift
@@ -9,6 +9,7 @@
 import Combine
 import ModernRIBs
 import CoreKit
+import StoryInterfaces
 
 protocol SearchResultInteractable: Interactable,
                                    SearchBeforeDashboardListener,
@@ -135,5 +136,24 @@ extension SearchResultRouter {
         searchAfterDashboardRouter?.viewControllable.uiviewController.view.isHidden = true
     }
 
+}
+
+// MARK: StoryDetail
+extension SearchResultRouter {
+    
+    func attachStoryDetail(storyId: Int) {
+    }
+    
+    func detachStroyDetail() {
+        
+    }
+    
+    func attachStroySeeAll(searchText: String) {
+        
+    }
+    
+    func detailStroySeeAll() {
+        
+    }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
@@ -30,13 +30,10 @@ protocol SearchRouterDependency {
 
 final class SearchRouter: ViewableRouter<SearchInteractable, SearchViewControllable>, SearchRouting {
     
-    private let searchCurrentLocationBuilder: SearchCurrentLocationStoryListBuildable
+    private let dependency: SearchRouterDependency
+    
     private var searchCurrentLocationRouter: ViewableRouting?
-    
-    private let searchResultBuilder: SearchResultBuildable
     private var searchResultRouter: SearchResultRouting?
-    
-    private let storyDeatilBuilder: StoryDetailBuildable
     private var storyDeatilRouter: ViewableRouting?
     
     init(
@@ -44,17 +41,14 @@ final class SearchRouter: ViewableRouter<SearchInteractable, SearchViewControlla
         viewController: SearchViewControllable,
         dependency: SearchRouterDependency
     ) {
-        self.searchCurrentLocationBuilder = dependency.searchCurrentLocationBuilder
-        self.searchResultBuilder = dependency.searchResultBuilder
-        self.storyDeatilBuilder = dependency.storyDeatilBuilder
-        
+        self.dependency = dependency
         super.init(interactor: interactor, viewController: viewController)
         interactor.router = self
     }
     
     func attachSearchCurrentLocation() {
         guard searchCurrentLocationRouter == nil else { return }
-        let router = searchCurrentLocationBuilder.build(withListener: interactor)
+        let router = dependency.searchCurrentLocationBuilder.build(withListener: interactor)
         attachChild(router)
         router.viewControllable.uiviewController.presentationController?.delegate = interactor.presentationAdapter
         viewController.present(router.viewControllable, animated: true)
@@ -70,7 +64,7 @@ final class SearchRouter: ViewableRouter<SearchInteractable, SearchViewControlla
     
     func attachSearchResult() {
         guard searchResultRouter == nil else { return }
-        let router = searchResultBuilder.build(withListener: interactor)
+        let router = dependency.searchResultBuilder.build(withListener: interactor)
         attachChild(router)
         searchResultRouter = router
         viewController.pushViewController(router.viewControllable, animated: true)
@@ -85,7 +79,7 @@ final class SearchRouter: ViewableRouter<SearchInteractable, SearchViewControlla
     
     func attachStoryDetail(storyID: Int) {
         guard storyDeatilRouter == nil else { return }
-        let router = storyDeatilBuilder.build(withListener: interactor, storyId: storyID)
+        let router = dependency.storyDeatilBuilder.build(withListener: interactor, storyId: storyID)
         attachChild(router)
         storyDeatilRouter = router
         viewController.pushViewController(router.viewControllable, animated: true)

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
@@ -9,6 +9,7 @@
 import CoreKit
 import ModernRIBs
 import BasePresentation
+import SearchInterfaces
 import StoryInterfaces
 
 protocol SearchInteractable: Interactable,

--- a/client/Targets/Presentation/Search/Interfaces/Sources/SearchInterface.swift
+++ b/client/Targets/Presentation/Search/Interfaces/Sources/SearchInterface.swift
@@ -1,1 +1,9 @@
-//Search.swift
+//
+//  SearchInterface.swift
+//  SearchInterfaces
+//
+//  Created by 이준복 on 11/29/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation

--- a/client/Targets/Presentation/Search/Interfaces/Sources/SearchInterface.swift
+++ b/client/Targets/Presentation/Search/Interfaces/Sources/SearchInterface.swift
@@ -6,4 +6,12 @@
 //  Copyright © 2023 codesquad. All rights reserved.
 //
 
-import Foundation
+import ModernRIBs
+
+public protocol SearchBuildable: Buildable {
+    func build(withListener listener: SearchListener) -> ViewableRouting
+}
+
+public protocol SearchListener: AnyObject {
+    
+}

--- a/client/Targets/Presentation/Search/Interfaces/Sources/SearchInterface.swift
+++ b/client/Targets/Presentation/Search/Interfaces/Sources/SearchInterface.swift
@@ -12,6 +12,4 @@ public protocol SearchBuildable: Buildable {
     func build(withListener listener: SearchListener) -> ViewableRouting
 }
 
-public protocol SearchListener: AnyObject {
-    
-}
+public protocol SearchListener: AnyObject { }


### PR DESCRIPTION
## 🌁 배경
- #279 

## ✅ 수정 내역
- 어제 부검한 UI 수정
- 스토리 클릭시 스토리 상세로 이동
- SearchInterface 생성 및 적용

## 📕 리뷰 노트
* PR를 볼 때 도움이 되는 항목 추가

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/71696675/d383db85-fda6-4465-adfe-d886613f2eda

시뮬레이터 키보드 에러
<img width="995" alt="image" src="https://github.com/boostcampwm2023/iOS04-HeatPick/assets/71696675/43e9a0e0-50bd-410a-a224-6f7a1bc7a7bb">
```
[UIKeyboardTaskQueue lockWhenReadyForMainThread] timeout waiting for task on queue
```
