### PR TITLE
인증 토큰 만료 로직 추가

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
@@ -114,9 +114,9 @@ final class AppRootComponent: Component<AppRootDependency>,
         if isDebug {
             let configuration = URLSessionConfiguration.ephemeral
             configuration.protocolClasses = protocols
-            return NetworkProvider(session: URLSession(configuration: configuration))
+            return NetworkProvider(session: URLSession(configuration: configuration), signOutService: SignoutService.shared)
         } else {
-            return NetworkProvider(session: URLSession.shared)
+            return NetworkProvider(session: URLSession.shared, signOutService: SignoutService.shared)
         }
     }
     

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkErrorCode.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkErrorCode.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public enum NetworkErrorCode: Int {
     
+    case unauthorized = 401
     case invalidToken = 498
     case internalServcerError = 500
     

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkProvider.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkProvider.swift
@@ -95,7 +95,7 @@ public final class NetworkProvider: Network {
             return .failure(error)
         }
         
-        return .success(Void())
+        return .success(())
     }
     
     private func executeUpload(_ request: URLRequest, from body: Data) async throws -> Result<Void, Error> {
@@ -104,7 +104,7 @@ public final class NetworkProvider: Network {
             return .failure(error)
         }
         
-        return .success(Void())
+        return .success(())
     }
     
     private func makeRequest(_ target: Target, isMultipartFormData: Bool = false) throws -> NetworkRequest {
@@ -172,9 +172,14 @@ public final class NetworkProvider: Network {
         
         if let errorCode = NetworkErrorCode(rawValue: httpResponse.statusCode) {
             switch errorCode {
+            case .unauthorized:
+                SignoutService.shared.signOut(type: .invalidToken)
+                return nil
+                
             case .invalidToken:
                 SignoutService.shared.signOut(type: .invalidToken)
                 return nil
+                
             case .internalServcerError:
                 return NetworkError.internalServer
             }

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkProvider.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkProvider.swift
@@ -18,9 +18,11 @@ public final class NetworkProvider: Network {
     }
     
     private let session: URLSession
+    private let signOutService: SignOutRequestServiceInterface
     
-    public init(session: URLSession) {
+    public init(session: URLSession, signOutService: SignOutRequestServiceInterface) {
         self.session = session
+        self.signOutService = signOutService
     }
     
     public func request<T: Decodable>(_ target: Target) async -> Result<T, Error> {
@@ -172,12 +174,8 @@ public final class NetworkProvider: Network {
         
         if let errorCode = NetworkErrorCode(rawValue: httpResponse.statusCode) {
             switch errorCode {
-            case .unauthorized:
-                SignoutService.shared.signOut(type: .invalidToken)
-                return nil
-                
-            case .invalidToken:
-                SignoutService.shared.signOut(type: .invalidToken)
+            case .unauthorized, .invalidToken:
+                signOutService.signOut(type: .invalidToken)
                 return nil
                 
             case .internalServcerError:


### PR DESCRIPTION
## 🌁 배경
* close #428 
* 로그에 Unauthorized가 떠서 추가했습니다.
* 자동으로 refresh 하도록 추가하면 좋을 것 같은데 아직 중요한 기능이 아니라 나중으로 미루겠습니다.

## ✅ 수정 내역
* 401 에러일 때 로그아웃하도록 추가
* Network에 로그아웃 서비스 의존성 추가

## ⚙️ 테스트 방법
* URLProtocol에 상태코드를 200에서 401로 변경하면 테스트 가능

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/f25e0ea0-1c88-4939-8336-4847dd129bee

