### PR TITLE
팔로우 기반 게시물 리턴 기능 구현

### DIFF
--- a/server/src/comment/comment.service.ts
+++ b/server/src/comment/comment.service.ts
@@ -19,7 +19,8 @@ export class CommentService {
   public async getMentionable({ storyId, userId }) {
     const mentionables: { userId: number; username: string }[] = [];
     const story: Story = await this.storyRepository.findOneByOption({ where: { storyId: storyId }, relations: ['user', 'comments', 'comments.user', 'comments.mentions'] });
-    mentionables.push({ userId: story.user.userId, username: story.user.username });
+    const storyUser = await story.user;
+    mentionables.push({ userId: storyUser.userId, username: storyUser.username });
     (await story.comments).forEach((comment) => {
       mentionables.push({ userId: comment.user.userId, username: comment.user.username });
     });

--- a/server/src/entities/story.entity.ts
+++ b/server/src/entities/story.entity.ts
@@ -13,7 +13,7 @@ export class Story {
   storyId: number;
 
   @ManyToOne(() => User, (user) => user.stories)
-  user: User;
+  user: Promise<User>;
 
   @Column()
   @ApiProperty({ description: 'Story의 제목' })

--- a/server/src/story/story.controller.ts
+++ b/server/src/story/story.controller.ts
@@ -14,7 +14,7 @@ import { StoryRecommendResponseDto, StoryResultDto } from 'src/search/dto/story.
 
 @ApiTags('story')
 @Controller('story')
-//@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard)
 export class StoryController {
   constructor(private storyService: StoryService) {}
 

--- a/server/src/story/story.controller.ts
+++ b/server/src/story/story.controller.ts
@@ -14,7 +14,7 @@ import { StoryRecommendResponseDto, StoryResultDto } from 'src/search/dto/story.
 
 @ApiTags('story')
 @Controller('story')
-@UseGuards(JwtAuthGuard)
+//@UseGuards(JwtAuthGuard)
 export class StoryController {
   constructor(private storyService: StoryService) {}
 
@@ -150,5 +150,13 @@ export class StoryController {
     const recommededStories = await this.storyService.getRecommendedStory(offset, limit);
     const isLastPage = recommededStories.length < limit ? true : false;
     return { recommededStories: recommededStories, isLastPage: isLastPage };
+  }
+
+  @Get('follow')
+  async getFollowStories(@Request() req: any, @Query('offset') offset: number = 0, @Query('limit') limit: number = 5, @Query('sortOption') sortOption: number = 0): Promise<StoryRecommendResponseDto> {
+    const userId = req.user.userRecordId;
+    const stories = await this.storyService.getFollowStories(userId, sortOption, offset, limit);
+    const isLastPage = stories.length < limit ? true : false;
+    return { recommededStories: stories, isLastPage: isLastPage };
   }
 }

--- a/server/src/util/story.entity.to.obj.ts
+++ b/server/src/util/story.entity.to.obj.ts
@@ -4,7 +4,8 @@ import { userEntityToUserObj } from './user.entity.to.obj';
 export async function storyEntityToObjWithOneImg(story: Story) {
   const images = await story.storyImages;
   const urls = await Promise.all(images.map(async (image) => image.imageUrl));
-  const user = userEntityToUserObj(story.user);
+  const userEntity = await story.user;
+  const user = userEntityToUserObj(userEntity);
   const categoryId = story.category ? story.category.categoryId : 0;
 
   return { storyId: story.storyId, title: story.title, content: story.content, likeCount: story.likeCount, commentCount: story.commentCount, storyImage: urls[0], categoryId: categoryId, user: user };
@@ -13,7 +14,8 @@ export async function storyEntityToObjWithOneImg(story: Story) {
 export async function storyEntityToObj(story: Story) {
   const images = await story.storyImages;
   const categoryId = story.category ? story.category.categoryId : 0;
-  const user = userEntityToUserObj(story.user);
+  const userEntity = await story.user;
+  const user = userEntityToUserObj(userEntity);
   const urls = images.map((image) => image.imageUrl);
   return { storyId: story.storyId, title: story.title, content: story.content, likeCount: story.likeCount, commentCount: story.commentCount, storyImages: urls, categoryId: categoryId, user: user };
 }


### PR DESCRIPTION
## 🌁 배경
* close #422 

## ✅ 수정 내역
- 현재 유저의 팔로우들의 게시물을 리턴합니다.
- sortOption을 파라미터로 줄 수 있으며, default 값은 0입니다.
- 0인 경우 최신순, 1인 경우 좋아요 순, 2인 경우 댓글 순으로 스토리를 리턴합니다.
- offset과 limit을 통해 원하는 양 만큼 스토리를 리턴받을 수 있으며 파라미터를 넘겨주지 않은 경우 offset은 0, limit은 5로 배정됩니다.



## 🎇 스크린샷
![image](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/51906365/85a9b716-cd8a-44dd-b1d9-e559bdb68fba)
