### PR TITLE
Label 개행 오류 수정

### DIFF
--- a/client/Targets/Core/CoreKit/Sources/CoreUtil/String+.swift
+++ b/client/Targets/Core/CoreKit/Sources/CoreUtil/String+.swift
@@ -1,0 +1,18 @@
+//
+//  String+.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public extension String {
+    
+    var withLineBreak: String {
+        let formatted = self.replacingOccurrences(of: "\\n", with: "\n")
+        return formatted
+    }
+    
+}

--- a/client/Targets/Data/Network/Home/Sources/DTO/RecommendLocationResponseDTO.swift
+++ b/client/Targets/Data/Network/Home/Sources/DTO/RecommendLocationResponseDTO.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreKit
 import DomainEntities
 
 public struct RecommendLocationResponseDTO: Decodable {
@@ -41,7 +42,7 @@ public extension RecommendLocationResponseDTO {
             .map { RecommendStory(
                 id: $0.storyId,
                 title: $0.title,
-                content: $0.content,
+                content: $0.content.withLineBreak,
                 imageURL: $0.storyImage ?? "",
                 likes: $0.likeCount,
                 comments: $0.commentCount,

--- a/client/Targets/Data/Network/Home/Sources/DTO/RecommendResponseDTO.swift
+++ b/client/Targets/Data/Network/Home/Sources/DTO/RecommendResponseDTO.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreKit
 import DomainEntities
 
 public struct RecommendResponseDTO: Decodable {
@@ -46,7 +47,7 @@ public extension RecommendResponseDTO {
             .map { HotPlaceStory(
                 id: $0.storyId,
                 title: $0.title,
-                content: $0.content,
+                content: $0.content.withLineBreak,
                 imageURL: $0.storyImage ?? "",
                 userId: $0.user.userId,
                 username: $0.user.username,

--- a/client/Targets/Data/Network/My/Sources/DTO/MyProfileResponseDTO.swift
+++ b/client/Targets/Data/Network/My/Sources/DTO/MyProfileResponseDTO.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreKit
 import DomainEntities
 
 public struct MyProfileResponseDTO: Decodable {
@@ -74,7 +75,7 @@ public extension MyProfileStoryResponseDTO {
         return .init(
             storyId: storyId,
             title: title, 
-            content: content,
+            content: content.withLineBreak,
             thumbnailImageURL: nil,
             likeCount: likeCount
         )

--- a/client/Targets/Data/Network/Search/Sources/DTO/SearchStroyDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/SearchStroyDTO.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreKit
 import DomainEntities
 
 public struct SearchStroyDTO: Decodable {
@@ -28,7 +29,7 @@ public extension SearchStroyDTO {
         SearchStory(
             storyId: self.storyId,
             title: self.title,
-            content: self.content,
+            content: self.content.withLineBreak,
             likeCount: self.likeCount,
             commentCount: self.commentCount,
             storyImage: self.storyImage,

--- a/client/Targets/Data/Network/Story/Sources/DTO/StoryDetailResponseDTO.swift
+++ b/client/Targets/Data/Network/Story/Sources/DTO/StoryDetailResponseDTO.swift
@@ -24,7 +24,7 @@ public struct StoryDetailResponseDTO: Decodable {
     public func toDomain() -> Story {
         return Story(id: story.storyId,
                      storyContent: StoryContent(title: story.title,
-                                                content: story.content,
+                                                content: story.content.withLineBreak,
                                                 date: story.createdAt,
                                                 imageUrls: story.storyImageURL,
                                                 category: StoryCategory(id: 0, title: story.category),

--- a/client/Targets/Data/Network/Story/Sources/DTO/StoryResponseDTO.swift
+++ b/client/Targets/Data/Network/Story/Sources/DTO/StoryResponseDTO.swift
@@ -30,7 +30,7 @@ public struct StoryResponseDTO: Decodable {
         self.badgeName = badgeName
         self.likeCount = likeCount
         self.commentCount = commentCount
-        self.content = content
+        self.content = content.withLineBreak
         self.place = place
     }
     


### PR DESCRIPTION
## 🌁 배경
* close #438 
* Label에 \n 그대로 표현되고 있어서 추가했습니다.
* 스토리 상세 내용에만 필요할 것 같아서 ResponseDTO에 story content가 있으면 변경하도록 추가했습니다.

## ✅ 수정 내역
* Story Content에 개행 replace 추가

## 🎇 스크린샷
|AS-IS|TO-BE|
|--|--|
|![IMG_5648](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/657e55ef-ac38-4c3f-80c1-bccaabbb24e0)|![IMG_5650](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/6ad68109-e10d-4913-a032-88e7247b70e0)|
|![IMG_5649](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/653ba018-6c8e-4c9b-b1df-cd0805a03b91)|![IMG_5651](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/3c9154dd-4d12-4238-96b1-05eae81c611b)|

