### PR TITLE
팔로잉 서비스 추가

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
@@ -51,6 +51,7 @@ final class AppRootComponent: Component<AppRootDependency>,
     let storyUseCase: StoryUseCaseInterface
     let myPageUseCase: MyPageUseCaseInterface
     let searchUseCase: SearchUseCaseInterface
+    let followingUseCase: FollowingUseCaseInterface
     
     let naverLoginRepository: NaverLoginRepositoryInterface
     let signOutRequestService: SignOutRequestServiceInterface
@@ -79,7 +80,7 @@ final class AppRootComponent: Component<AppRootDependency>,
         StoryEditorBuilder(dependency: self)
     }()
     
-    lazy var storyDeatilBuilder: StoryDetailBuildable = {
+    lazy var storyDetailBuilder: StoryDetailBuildable = {
         StoryDetailBuilder(dependency: self)
     }()
     
@@ -112,6 +113,9 @@ final class AppRootComponent: Component<AppRootDependency>,
         
         let searchNetworkProvider = AppRootComponent.generateNetworkProvider(isDebug: false, protocols: [SearchURLProtocol.self])
         self.searchUseCase = SearchUseCase(repository: SearchRepository(session: searchNetworkProvider), locationService: locationService)
+        
+        let followingNetworkProvider = AppRootComponent.generateNetworkProvider(isDebug: false, protocols: [])
+        self.followingUseCase = FollowingUseCase(repository: FollowingRepository(session: followingNetworkProvider))
         
         super.init(dependency: dependency)
     }

--- a/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootInteractor.swift
@@ -13,6 +13,7 @@ protocol AppRootRouting: ViewableRouting {
     func attachSignIn()
     func detachSignIn()
     func attachTabs()
+    func selectFollowing()
 }
 
 protocol AppRootPresentable: Presentable {
@@ -61,6 +62,12 @@ final class AppRootInteractor: PresentableInteractor<AppRootPresentable>, AppRoo
     func signInDidComplete() {
         router?.detachSignIn()
         router?.attachTabs()
+    }
+    
+    // MARK: - Home
+    
+    func homeDidTapFollowing() {
+        router?.selectFollowing()
     }
     
 }

--- a/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootRouter.swift
@@ -28,6 +28,7 @@ protocol AppRootInteractable: Interactable,
 
 protocol AppRootViewControllable: ViewControllable {
     func setViewControllers(_ viewControllers: [ViewControllable])
+    func selectViewController(_ viewController: ViewControllable)
 }
 
 protocol AppRootRouterDependency: AnyObject {
@@ -45,7 +46,7 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
     private var signInRouter: Routing?
     private var homeRouter: Routing?
     private var searchHomeRouter: Routing?
-    private var followingRouter: Routing?
+    private var followingRouter: ViewableRouting?
     private var myPageRouter: Routing?
     
     init(
@@ -107,6 +108,11 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
         ]
         
         viewController.setViewControllers(viewControllers)
+    }
+    
+    func selectFollowing() {
+        guard let router = followingRouter else { return }
+        viewController.selectViewController(router.viewControllable)
     }
     
 }

--- a/client/Targets/App/Sources/AppRoot/AppRootTabBarController.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootTabBarController.swift
@@ -26,6 +26,20 @@ final class AppRootTabBarController: UITabBarController, AppRootPresentable, App
         super.setViewControllers(viewControllers.map(\.uiviewController), animated: false)
     }
     
+    func selectViewController(_ viewController: ViewControllable) {
+        guard let index = viewControllers?.firstIndex(where: { controller in
+            if let navigation = controller as? UINavigationController {
+                return navigation.topViewController == viewController.uiviewController
+                
+            } else {
+                return controller == viewController.uiviewController
+            }
+        }) else {
+            return
+        }
+        selectedIndex = index
+    }
+    
     private func setupTabBar() {
         let appearance: UITabBarAppearance = tabBar.standardAppearance
         appearance.configureWithDefaultBackground()

--- a/client/Targets/Data/Repositories/Sources/FollowingRepository.swift
+++ b/client/Targets/Data/Repositories/Sources/FollowingRepository.swift
@@ -1,0 +1,29 @@
+//
+//  FollowingRepository.swift
+//  DataRepositories
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import HomeAPI
+import NetworkAPIKit
+import DomainEntities
+import DomainInterfaces
+
+public final class FollowingRepository: FollowingRepositoryInterface {
+    
+    private let session: Network
+    
+    public init(session: Network) {
+        self.session = session
+    }
+    
+    public func fetchFollowing(offset: Int, limit: Int, sortOption: Int) async -> Result<HomeFollowingStoryWithPaging, Error> {
+        let target = HomeAPI.followWithPaging(offset: offset, limit: limit, sortOption: sortOption)
+        let request: Result<HomeFollowResponseDTO, Error> = await session.request(target)
+        return request.map { $0.toDomain() }
+    }
+    
+}

--- a/client/Targets/Domain/Entities/Sources/Home/HomeFollowingSortOption.swift
+++ b/client/Targets/Domain/Entities/Sources/Home/HomeFollowingSortOption.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum HomeFollowingSortOption: Int {
+public enum HomeFollowingSortOption: Int, CaseIterable {
     
     case recent = 0
     case like

--- a/client/Targets/Domain/Interfaces/Sources/Repository/FollowingRepositoryInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/Repository/FollowingRepositoryInterface.swift
@@ -1,0 +1,16 @@
+//
+//  FollowingRepositoryInterface.swift
+//  DomainInterfaces
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import DomainEntities
+
+public protocol FollowingRepositoryInterface: AnyObject {
+    
+    func fetchFollowing(offset: Int, limit: Int, sortOption: Int) async -> Result<HomeFollowingStoryWithPaging, Error>
+    
+}

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Following/FollowingUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Following/FollowingUseCaseInterface.swift
@@ -1,0 +1,19 @@
+//
+//  FollowingUseCaseInterface.swift
+//  DomainInterfaces
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import DomainEntities
+
+public protocol FollowingUseCaseInterface: AnyObject {
+    
+    var hasMore: Bool { get }
+    func fetchFollowing() async -> Result<[HomeFollowingStory], Error>
+    func fetchFollowing(option: HomeFollowingSortOption) async -> Result<[HomeFollowingStory], Error>
+    func loadMoreFollowing() async -> Result<[HomeFollowingStory], Error>
+    
+}

--- a/client/Targets/Domain/UseCases/Sources/FollowingUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/FollowingUseCase.swift
@@ -1,0 +1,57 @@
+//
+//  FollowingUseCase.swift
+//  DomainUseCases
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import CoreKit
+import DomainEntities
+import DomainInterfaces
+
+public final class FollowingUseCase: FollowingUseCaseInterface {
+    
+    public var hasMore: Bool {
+        return !isLastPage
+    }
+    
+    private let repository: FollowingRepositoryInterface
+    private var isLastPage = true
+    private var option: HomeFollowingSortOption = .recent
+    private var followingOffset = 0
+    private let pageLimit = 10
+    
+    public init(repository: FollowingRepositoryInterface) {
+        self.repository = repository
+    }
+    
+    public func fetchFollowing() async -> Result<[HomeFollowingStory], Error> {
+        followingOffset = 0
+        return await fetchFollowing(offset: followingOffset)
+    }
+    
+    public func fetchFollowing(option: HomeFollowingSortOption) async -> Result<[HomeFollowingStory], Error> {
+        self.option = option
+        return await fetchFollowing()
+    }
+    
+    public func loadMoreFollowing() async -> Result<[HomeFollowingStory], Error> {
+        followingOffset += 1
+        return await fetchFollowing(offset: followingOffset)
+    }
+    
+    private func fetchFollowing(offset: Int) async -> Result<[HomeFollowingStory], Error> {
+        let result = await repository.fetchFollowing(offset: offset, limit: pageLimit, sortOption: option.rawValue)
+        switch result {
+        case .success(let follwoing):
+            isLastPage = follwoing.isLastPage
+            
+        case .failure:
+            isLastPage = true
+        }
+        return result.map(\.stories)
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingHome/FollowingHomeBuilder.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingHome/FollowingHomeBuilder.swift
@@ -7,11 +7,19 @@
 //
 
 import ModernRIBs
+import DomainInterfaces
 import FollowingInterfaces
+import StoryInterfaces
 
-public protocol FollowingHomeDependency: Dependency {}
+public protocol FollowingHomeDependency: Dependency {
+    var followingUseCase: FollowingUseCaseInterface { get }
+    var storyDetailBuilder: StoryDetailBuildable { get }
+}
 
-final class FollowingHomeComponent: Component<FollowingHomeDependency> {}
+final class FollowingHomeComponent: Component<FollowingHomeDependency>, FollowingListDependency {
+    var followingUseCase: FollowingUseCaseInterface { dependency.followingUseCase }
+    var storyDetailBuilder: StoryDetailBuildable { dependency.storyDetailBuilder }
+}
 
 public final class FollowingHomeBuilder: Builder<FollowingHomeDependency>, FollowingHomeBuildable {
     
@@ -24,7 +32,12 @@ public final class FollowingHomeBuilder: Builder<FollowingHomeDependency>, Follo
         let viewController = FollowingHomeViewController()
         let interactor = FollowingHomeInteractor(presenter: viewController)
         interactor.listener = listener
-        return FollowingHomeRouter(interactor: interactor, viewController: viewController)
+        return FollowingHomeRouter(
+            interactor: interactor,
+            viewController: viewController,
+            followingListBuilder: FollowingListBuilder(dependency: component),
+            storyDetailBuilder: component.storyDetailBuilder
+        )
     }
     
 }

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingHome/FollowingHomeInteractor.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingHome/FollowingHomeInteractor.swift
@@ -9,7 +9,11 @@
 import ModernRIBs
 import FollowingInterfaces
 
-protocol FollowingHomeRouting: ViewableRouting {}
+protocol FollowingHomeRouting: ViewableRouting {
+    func attachFollowingList()
+    func attachStoryDetail(id: Int)
+    func detachStoryDetail()
+}
 
 protocol FollowingHomePresentable: Presentable {
     var listener: FollowingHomePresentableListener? { get set }
@@ -28,10 +32,19 @@ final class FollowingHomeInteractor: PresentableInteractor<FollowingHomePresenta
     
     override func didBecomeActive() {
         super.didBecomeActive()
+        router?.attachFollowingList()
     }
     
     override func willResignActive() {
         super.willResignActive()
+    }
+    
+    func followingListDidTapStory(id: Int) {
+        router?.attachStoryDetail(id: id)
+    }
+    
+    func storyDetailDidTapClose() {
+        router?.detachStoryDetail()
     }
     
 }

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingHome/FollowingHomeViewController.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingHome/FollowingHomeViewController.swift
@@ -23,26 +23,6 @@ final class FollowingHomeViewController: UIViewController, FollowingHomePresenta
     
     weak var listener: FollowingHomePresentableListener?
     
-    private let scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        scrollView.contentInset = .zero
-        scrollView.showsHorizontalScrollIndicator = false
-        scrollView.showsVerticalScrollIndicator = false
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.contentInset = Constant.contentInset
-        return scrollView
-    }()
-    
-    private let stackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.alignment = .fill
-        stackView.distribution = .equalSpacing
-        stackView.spacing = 60
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
-    }()
-    
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         setupTabBar()
@@ -61,13 +41,21 @@ final class FollowingHomeViewController: UIViewController, FollowingHomePresenta
     func setDashboard(_ viewControllable: ViewControllable) {
         let viewController = viewControllable.uiviewController
         addChild(viewController)
-        stackView.addArrangedSubview(viewController.view)
+        view.addSubview(viewController.view)
+        viewController.view.translatesAutoresizingMaskIntoConstraints = false
         viewController.didMove(toParent: self)
+        
+        NSLayoutConstraint.activate([
+            viewController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            viewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            viewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            viewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
     }
     
     func removeDashboard(_ viewControllable: ViewControllable) {
         let viewController = viewControllable.uiviewController
-        stackView.removeArrangedSubview(viewController.view)
+        viewController.view.removeFromSuperview()
         viewController.removeFromParent()
     }
     
@@ -77,20 +65,6 @@ private extension FollowingHomeViewController {
     
     func setupViews() {
         view.backgroundColor = .hpWhite
-        view.addSubview(scrollView)
-        scrollView.addSubview(stackView)
-        
-        NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            
-            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
-        ])
     }
     
     func setupTabBar() {

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/FollowingListBuilder.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/FollowingListBuilder.swift
@@ -1,0 +1,38 @@
+//
+//  FollowingListBuilder.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+import DomainInterfaces
+
+protocol FollowingListDependency: Dependency {
+    var followingUseCase: FollowingUseCaseInterface { get }
+}
+
+final class FollowingListComponent: Component<FollowingListDependency>, FollowingListInteractorDependency {
+    var followingUseCase: FollowingUseCaseInterface { dependency.followingUseCase }
+}
+
+protocol FollowingListBuildable: Buildable {
+    func build(withListener listener: FollowingListListener) -> FollowingListRouting
+}
+
+final class FollowingListBuilder: Builder<FollowingListDependency>, FollowingListBuildable {
+    
+    override init(dependency: FollowingListDependency) {
+        super.init(dependency: dependency)
+    }
+    
+    func build(withListener listener: FollowingListListener) -> FollowingListRouting {
+        let component = FollowingListComponent(dependency: dependency)
+        let viewController = FollowingListViewController()
+        let interactor = FollowingListInteractor(presenter: viewController, dependency: component)
+        interactor.listener = listener
+        return FollowingListRouter(interactor: interactor, viewController: viewController)
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/FollowingListInteractor.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/FollowingListInteractor.swift
@@ -1,0 +1,143 @@
+//
+//  FollowingListInteractor.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import ModernRIBs
+import CoreKit
+import DomainEntities
+import DomainInterfaces
+
+protocol FollowingListRouting: ViewableRouting {}
+
+protocol FollowingListPresentable: Presentable {
+    var listener: FollowingListPresentableListener? { get set }
+    func setup(models: [FollowingListCellModel])
+    func append(models: [FollowingListCellModel])
+}
+
+protocol FollowingListListener: AnyObject {
+    func followingListDidTapStory(id: Int)
+}
+
+protocol FollowingListInteractorDependency: AnyObject {
+    var followingUseCase: FollowingUseCaseInterface { get }
+}
+
+final class FollowingListInteractor: PresentableInteractor<FollowingListPresentable>, FollowingListInteractable, FollowingListPresentableListener {
+    
+    weak var router: FollowingListRouting?
+    weak var listener: FollowingListListener?
+    
+    private let dependency: FollowingListInteractorDependency
+    private let cancelBag = CancelBag()
+    private var stories: [HomeFollowingStory] = []
+    private var isLoading = false
+    
+    init(
+        presenter: FollowingListPresentable,
+        dependency: FollowingListInteractorDependency
+    ) {
+        self.dependency = dependency
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+    
+    override func didBecomeActive() {
+        super.didBecomeActive()
+        fetchFollowing()
+    }
+    
+    override func willResignActive() {
+        super.willResignActive()
+        cancelBag.cancel()
+    }
+    
+    func didTapItem(at indexPath: IndexPath) {
+        guard let story = stories[safe: indexPath.row] else { return }
+        listener?.followingListDidTapStory(id: story.storyId)
+    }
+    
+    func willDisplay(at indexPath: IndexPath) {
+        guard indexPath.row == stories.count - 1 else { return }
+        loadMoreIfNeeded()
+    }
+    
+    func didTapOption(option: HomeFollowingSortOption) {
+        cancelBag.cancel()
+        stopLoading()
+        fetchFollowing(option: option)
+    }
+    
+    private func fetchFollowing(option: HomeFollowingSortOption = .recent) {
+        startLoading()
+        Task { [weak self] in
+            guard let self else { return }
+            await dependency.followingUseCase
+                .fetchFollowing(option: option)
+                .onSuccess(on: .main, with: self) { this, stories in
+                    let models = stories.map { $0.toModel() }
+                    this.stories = stories
+                    this.presenter.setup(models: models)
+                    this.stopLoading()
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: error.localizedDescription, log: .interactor)
+                    this.stopLoading()
+                }
+        }.store(in: cancelBag)
+    }
+    
+    private func loadMoreIfNeeded() {
+        guard dependency.followingUseCase.hasMore, isLoading == false else {
+            return
+        }
+        
+        Task { [weak self] in
+            guard let self else { return }
+            await dependency.followingUseCase
+                .loadMoreFollowing()
+                .onSuccess(on: .main, with: self) { this, stories in
+                    let models = stories.map { $0.toModel() }
+                    this.stories.append(contentsOf: stories)
+                    this.presenter.append(models: models)
+                    this.stopLoading()
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: error.localizedDescription, log: .interactor)
+                    this.stopLoading()
+                }
+        }.store(in: cancelBag)
+    }
+    
+    private func startLoading() {
+        isLoading = true
+    }
+    
+    private func stopLoading() {
+        isLoading = false
+    }
+    
+}
+
+private extension HomeFollowingStory {
+    
+    func toModel() -> FollowingListCellModel {
+        return .init(
+            profileModel: .init(
+                profileImageURL: userProfileImageURL,
+                nickname: username
+            ),
+            thumbnailImageURL: imageURL,
+            likes: likes,
+            comments: comments,
+            title: title,
+            subtitle: content
+        )
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/FollowingListRouter.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/FollowingListRouter.swift
@@ -1,0 +1,25 @@
+//
+//  FollowingListRouter.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol FollowingListInteractable: Interactable {
+    var router: FollowingListRouting? { get set }
+    var listener: FollowingListListener? { get set }
+}
+
+protocol FollowingListViewControllable: ViewControllable {}
+
+final class FollowingListRouter: ViewableRouter<FollowingListInteractable, FollowingListViewControllable>, FollowingListRouting {
+    
+    override init(interactor: FollowingListInteractable, viewController: FollowingListViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/FollowingListViewController.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/FollowingListViewController.swift
@@ -1,0 +1,142 @@
+//
+//  FollowingListViewController.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+import UIKit
+import DomainEntities
+
+protocol FollowingListPresentableListener: AnyObject {
+    func didTapItem(at indexPath: IndexPath)
+    func didTapOption(option: HomeFollowingSortOption)
+    func willDisplay(at indexPath: IndexPath)
+}
+
+final class FollowingListViewController: UIViewController, FollowingListPresentable, FollowingListViewControllable {
+    
+    weak var listener: FollowingListPresentableListener?
+    
+    private var models: [FollowingListCellModel] = []
+    
+    private lazy var titleView: FollowingTitleView = {
+        let titleView = FollowingTitleView()
+        titleView.delegate = self
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        return titleView
+    }()
+    
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .grouped)
+        tableView.backgroundColor = .white
+        tableView.register(FollowingListCell.self)
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.contentInset = .zero
+        tableView.separatorStyle = .none
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        return tableView
+    }()
+    
+    private let separator: UIView = {
+        let view = UIView()
+        view.backgroundColor = .hpGray4
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupViews()
+    }
+    
+    func setup(models: [FollowingListCellModel]) {
+        self.models = models
+        tableView.reloadData()
+    }
+    
+    func append(models: [FollowingListCellModel]) {
+        self.models.append(contentsOf: models)
+        tableView.reloadData()
+    }
+    
+}
+
+extension FollowingListViewController: FollowingTitleViewDelegate {
+    
+    func followingDropDownViewDidSelectOption(_ view: FollowingDropDownView, option: HomeFollowingSortOption) {
+        listener?.didTapOption(option: option)
+    }
+    
+}
+
+extension FollowingListViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        listener?.didTapItem(at: indexPath)
+    }
+    
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        listener?.willDisplay(at: indexPath)
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        separator.isHidden = scrollView.contentOffset.y < 20
+    }
+    
+}
+
+extension FollowingListViewController: UITableViewDataSource {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return models.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let model = models[safe: indexPath.row] else {
+            return UITableViewCell()
+        }
+        let cell = tableView.dequeue(FollowingListCell.self, for: indexPath)
+        cell.setup(model: model)
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return nil
+    }
+    
+}
+
+private extension FollowingListViewController {
+    
+    func setupViews() {
+        view.backgroundColor = .hpWhite
+        
+        [titleView, separator, tableView].forEach(view.addSubview)
+        
+        NSLayoutConstraint.activate([
+            titleView.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
+            titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            titleView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            
+            separator.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: 20),
+            separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            separator.heightAnchor.constraint(equalToConstant: 1),
+            
+            tableView.topAnchor.constraint(equalTo: separator.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingDropDownView.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingDropDownView.swift
@@ -1,0 +1,114 @@
+//
+//  FollowingDropDownView.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import DesignKit
+import DomainEntities
+
+protocol FollowingDropDownViewDelegate: AnyObject {
+    
+    func followingDropDownViewDidSelectOption(_ view: FollowingDropDownView, option: HomeFollowingSortOption)
+    
+}
+
+final class FollowingDropDownView: UIView {
+    
+    private enum Constant {
+        static let imageName = "chevron.down"
+        static let imageWidth: CGFloat = 15
+        static let imageHeight = imageWidth
+    }
+    
+    weak var delegate: FollowingDropDownViewDelegate?
+    private var options: [HomeFollowingSortOption] = []
+    
+    private let containerButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .hpWhite
+        button.setTitleColor(.clear, for: .normal)
+        button.layer.borderWidth = 1
+        button.layer.borderColor = UIColor.hpGray4.cgColor
+        button.layer.cornerRadius = Constants.cornerRadiusMedium
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(systemName: Constant.imageName)?.withRenderingMode(.alwaysTemplate)
+        imageView.tintColor = .hpBlack
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "최신순"
+        label.textColor = .hpBlack
+        label.font = .captionRegular
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+    func setup(options: [HomeFollowingSortOption]) {
+        self.options = options
+        
+        let menu = options.map { option -> UIAction in
+            return UIAction(title: option.title) { [weak self] action in
+                self?.titleLabel.text = action.title
+                self?.didSelectOption(title: action.title)
+            }
+        }
+        containerButton.menu = UIMenu(options: .displayInline, children: menu)
+        containerButton.showsMenuAsPrimaryAction = true
+        containerButton.changesSelectionAsPrimaryAction = true
+    }
+    
+}
+
+private extension FollowingDropDownView {
+    
+    func setupViews() {
+        addSubview(containerButton)
+        [imageView, titleLabel].forEach(containerButton.addSubview)
+        
+        NSLayoutConstraint.activate([
+            containerButton.topAnchor.constraint(equalTo: topAnchor),
+            containerButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+            containerButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+            containerButton.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            imageView.widthAnchor.constraint(equalToConstant: Constant.imageWidth),
+            imageView.heightAnchor.constraint(equalToConstant: Constant.imageHeight),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            imageView.trailingAnchor.constraint(equalTo: containerButton.trailingAnchor, constant: -20),
+            
+            titleLabel.topAnchor.constraint(equalTo: containerButton.topAnchor, constant: 5),
+            titleLabel.leadingAnchor.constraint(equalTo: containerButton.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: imageView.leadingAnchor, constant: -10),
+            titleLabel.bottomAnchor.constraint(equalTo: containerButton.bottomAnchor, constant: -5)
+        ])
+    }
+    
+    func didSelectOption(title: String) {
+        guard let option = options.first(where: { $0.title == title }) else { return }
+        delegate?.followingDropDownViewDidSelectOption(self, option: option)
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingListCell.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingListCell.swift
@@ -1,0 +1,135 @@
+//
+//  FollowingListCell.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import CoreKit
+import DesignKit
+
+struct FollowingListCellModel {
+    let profileModel: FollowingListProfileViewModel
+    let thumbnailImageURL: String
+    let likes: Int
+    let comments: Int
+    let title: String
+    let subtitle: String
+}
+
+final class FollowingListCell: UITableViewCell {
+    
+    private let separator: UIView = {
+        let view = UIView()
+        view.backgroundColor = .hpGray4
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let profileView: FollowingListProfileView = {
+        let view = FollowingListProfileView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let thumbnailImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .hpGray4
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = Constants.cornerRadiusMedium
+        imageView.contentMode = .scaleAspectFill
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private let commentView: FollowingListCommnetView = {
+        let view = FollowingListCommnetView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodySemibold
+        label.textColor = .hpBlack
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .captionRegular
+        label.textColor = .hpBlack
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        profileView.clear()
+        commentView.clear()
+        titleLabel.text = nil
+        subtitleLabel.text = nil
+        thumbnailImageView.cancel()
+        thumbnailImageView.image = nil
+    }
+    
+    func setup(model: FollowingListCellModel) {
+        profileView.setup(model: model.profileModel)
+        thumbnailImageView.load(from: model.thumbnailImageURL)
+        commentView.setup(likes: model.likes, comments: model.comments)
+        titleLabel.text = model.title
+        subtitleLabel.text = model.subtitle
+    }
+    
+}
+
+private extension FollowingListCell {
+    
+    func setupViews() {
+        selectionStyle = .none
+        
+        [separator, profileView, thumbnailImageView, commentView, titleLabel, subtitleLabel].forEach(contentView.addSubview)
+        
+        NSLayoutConstraint.activate([
+            separator.topAnchor.constraint(equalTo: contentView.topAnchor),
+            separator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            separator.heightAnchor.constraint(equalToConstant: 1),
+            
+            profileView.topAnchor.constraint(equalTo: separator.bottomAnchor, constant: 20),
+            profileView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.leadingOffset),
+            profileView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: Constants.traillingOffset),
+            
+            thumbnailImageView.topAnchor.constraint(equalTo: profileView.bottomAnchor, constant: 10),
+            thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.leadingOffset),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: Constants.traillingOffset),
+            thumbnailImageView.heightAnchor.constraint(equalToConstant: 200),
+            
+            commentView.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: 10),
+            commentView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.leadingOffset),
+            
+            titleLabel.topAnchor.constraint(equalTo: commentView.bottomAnchor, constant: 10),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.leadingOffset),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.traillingOffset),
+            
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
+            subtitleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.leadingOffset),
+            subtitleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: Constants.traillingOffset),
+            subtitleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -20)
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingListCommnetView.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingListCommnetView.swift
@@ -1,0 +1,102 @@
+//
+//  FollowingListCommnetView.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import DesignKit
+
+final class FollowingListCommnetView: UIView {
+    
+    private enum Constant {
+        static let likeImageName = "heart"
+        static let commentImageName = "message"
+        static let imageWidth: CGFloat = 15
+        static let imageHeight: CGFloat = 15
+    }
+    
+    private let likeImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: Constant.likeImageName)
+        imageView.tintColor = .hpBlack
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private let likeLabel: UILabel = {
+        let label = UILabel()
+        label.font = .smallSemibold
+        label.textColor = .hpBlack
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let commentImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: Constant.commentImageName)
+        imageView.tintColor = .hpBlack
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private let commentLabel: UILabel = {
+        let label = UILabel()
+        label.font = .smallSemibold
+        label.textColor = .hpBlack
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+    func setup(likes: Int, comments: Int) {
+        likeLabel.text = "\(likes)"
+        commentLabel.text = "\(comments)"
+    }
+    
+    func clear() {
+        likeLabel.text = "0"
+        commentLabel.text = "0"
+    }
+    
+}
+
+private extension FollowingListCommnetView {
+    
+    func setupViews() {
+        [likeImageView, likeLabel, commentImageView, commentLabel].forEach(addSubview)
+        
+        NSLayoutConstraint.activate([
+            likeImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            likeImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            likeImageView.widthAnchor.constraint(equalToConstant: Constant.imageWidth),
+            likeImageView.heightAnchor.constraint(equalToConstant: Constant.imageHeight),
+            
+            likeLabel.topAnchor.constraint(equalTo: topAnchor),
+            likeLabel.leadingAnchor.constraint(equalTo: likeImageView.trailingAnchor, constant: 1),
+            likeLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            commentImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            commentImageView.leadingAnchor.constraint(equalTo: likeLabel.trailingAnchor, constant: 10),
+            commentImageView.widthAnchor.constraint(equalToConstant: Constant.imageWidth),
+            commentImageView.heightAnchor.constraint(equalToConstant: Constant.imageHeight),
+            
+            commentLabel.topAnchor.constraint(equalTo: topAnchor),
+            commentLabel.leadingAnchor.constraint(equalTo: commentImageView.trailingAnchor, constant: 1),
+            commentLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            commentLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingListProfileView.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingListProfileView.swift
@@ -1,0 +1,85 @@
+//
+//  FollowingListProfileView.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import CoreKit
+import DesignKit
+
+struct FollowingListProfileViewModel {
+    let profileImageURL: String?
+    let nickname: String
+}
+
+final class FollowingListProfileView: UIView {
+    
+    private enum Constant {
+        static let profileImageWidth: CGFloat = 40
+        static let profileImageHeight: CGFloat = 40
+        static let labelLeadingConstant: CGFloat = 10
+    }
+    
+    private let profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = Constant.profileImageHeight / 2
+        imageView.contentMode = .scaleAspectFill
+        imageView.backgroundColor = .hpGray3
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private let nicknameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .captionSemibold
+        label.textColor = .hpBlack
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+    func setup(model: FollowingListProfileViewModel) {
+        profileImageView.load(from: model.profileImageURL)
+        nicknameLabel.text = model.nickname
+    }
+    
+    func clear() {
+        profileImageView.cancel()
+        profileImageView.image = nil
+        nicknameLabel.text = nil
+    }
+    
+}
+
+private extension FollowingListProfileView {
+    
+    func setupViews() {
+        [profileImageView, nicknameLabel].forEach(addSubview)
+        
+        NSLayoutConstraint.activate([
+            profileImageView.topAnchor.constraint(equalTo: topAnchor),
+            profileImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            profileImageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            profileImageView.widthAnchor.constraint(equalToConstant: Constant.profileImageWidth),
+            profileImageView.heightAnchor.constraint(equalToConstant: Constant.profileImageHeight),
+            
+            nicknameLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            nicknameLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: Constant.labelLeadingConstant),
+            nicknameLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingTitleView.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingList/Views/FollowingTitleView.swift
@@ -1,0 +1,65 @@
+//
+//  FollowingTitleView.swift
+//  FollowingImplementations
+//
+//  Created by 홍성준 on 11/30/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import DesignKit
+import DomainEntities
+
+typealias FollowingTitleViewDelegate = FollowingDropDownViewDelegate
+
+final class FollowingTitleView: UIView {
+    
+    weak var delegate: FollowingTitleViewDelegate? {
+        didSet { dropDownView.delegate = self.delegate }
+    }
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.text = "팔로잉"
+        label.textColor = .hpBlack
+        label.font = .largeBold
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let dropDownView: FollowingDropDownView = {
+        let dropDownView = FollowingDropDownView()
+        dropDownView.setup(options: HomeFollowingSortOption.allCases)
+        dropDownView.translatesAutoresizingMaskIntoConstraints = false
+        return dropDownView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+}
+
+private extension FollowingTitleView {
+    
+    func setupViews() {
+        [titleLabel, dropDownView].forEach(addSubview)
+        
+        NSLayoutConstraint.activate([
+            dropDownView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            dropDownView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: dropDownView.leadingAnchor, constant: -20),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeBuilder.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeBuilder.swift
@@ -13,7 +13,7 @@ import StoryInterfaces
 
 public protocol HomeDependency: Dependency {
     var homeUseCase: HomeUseCaseInterface { get }
-    var storyDeatilBuilder: StoryDetailBuildable { get }
+    var storyDetailBuilder: StoryDetailBuildable { get }
 }
 
 final class HomeComponent: Component<HomeDependency>,
@@ -26,7 +26,7 @@ final class HomeComponent: Component<HomeDependency>,
     var recommendUseCase: RecommendUseCaseInterface { dependency.homeUseCase }
     var hotPlaceUseCase: HotPlaceUseCaseInterface { dependency.homeUseCase }
     var followingUseCase: HomeFollowingUseCaseInterface { dependency.homeUseCase }
-    var storyDeatilBuilder: StoryDetailBuildable { dependency.storyDeatilBuilder }
+    var storyDetailBuilder: StoryDetailBuildable { dependency.storyDetailBuilder }
 }
 
 public final class HomeBuilder: Builder<HomeDependency>, HomeBuildable {

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
@@ -77,7 +77,7 @@ final class HomeInteractor: PresentableInteractor<HomePresentable>, HomeInteract
     // MARK: - Following
     
     func followingDashboardDidTapSeeAll() {
-        print("# Attach Following See All View")
+        listener?.homeDidTapFollowing()
     }
     
     func followingDashboardDidTapStory(id: Int) {

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeRouterComponent.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeRouterComponent.swift
@@ -18,7 +18,7 @@ final class HomeRouterComponent: HomeRouterDependency {
     init(component: HomeComponent) {
         self.base = HomeBaseRouterComponent(component: component)
         self.seeAll = HomeSeeAllRouterComponent(component: component)
-        self.storyDetailBuilder = component.storyDeatilBuilder
+        self.storyDetailBuilder = component.storyDetailBuilder
     }
     
 }

--- a/client/Targets/Presentation/Home/Interfaces/Sources/HomeInterface.swift
+++ b/client/Targets/Presentation/Home/Interfaces/Sources/HomeInterface.swift
@@ -12,4 +12,6 @@ public protocol HomeBuildable: Buildable {
     func build(withListener listener: HomeListener) -> ViewableRouting
 }
 
-public protocol HomeListener: AnyObject {}
+public protocol HomeListener: AnyObject {
+    func homeDidTapFollowing()
+}

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchBuilder.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchBuilder.swift
@@ -15,7 +15,7 @@ import DomainInterfaces
 public protocol SearchDependency: Dependency {
     var searchUseCase: SearchUseCaseInterface { get }
     var storyEditorBuilder: StoryEditorBuildable { get }
-    var storyDeatilBuilder: StoryDetailBuildable { get }
+    var storyDetailBuilder: StoryDetailBuildable { get }
 }
 
 final class SearchComponent: Component<SearchDependency>,
@@ -29,7 +29,7 @@ final class SearchComponent: Component<SearchDependency>,
     var searchResultUseCase: SearchResultUseCaseInterface { dependency.searchUseCase }
     var searchMapUseCase: SearchMapUseCaseInterface { dependency.searchUseCase }
     var storyEditorBuilder: StoryEditorBuildable { dependency.storyEditorBuilder }
-    var storyDeatilBuilder: StoryDetailBuildable { dependency.storyDeatilBuilder }
+    var storyDetailBuilder: StoryDetailBuildable { dependency.storyDetailBuilder }
     var searchStorySeeAllUseCase: SearchStorySeeAllUseCaseInterface { dependency.searchUseCase }
     
 }
@@ -39,14 +39,14 @@ final class SearchRouterComponent: SearchRouterDependency {
     let searchCurrentLocationBuilder: SearchCurrentLocationStoryListBuildable
     let searchResultBuilder: SearchResultBuildable
     let storyEditorBuilder: StoryEditorBuildable
-    let storyDeatilBuilder: StoryDetailBuildable
+    let storyDetailBuilder: StoryDetailBuildable
     let searchStorySeeAllBuilder: SearchStorySeeAllBuildable
     
     init(component: SearchComponent) {
         self.searchCurrentLocationBuilder = SearchCurrentLocationStoryListBuilder(dependency: component)
         self.searchResultBuilder = SearchResultBuilder(dependency: component)
         self.storyEditorBuilder = component.storyEditorBuilder
-        self.storyDeatilBuilder = component.storyDeatilBuilder
+        self.storyDetailBuilder = component.storyDetailBuilder
         self.searchStorySeeAllBuilder = SearchStorySeeAllBuilder(dependency: component)
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
@@ -30,7 +30,7 @@ protocol SearchRouterDependency {
     var searchCurrentLocationBuilder: SearchCurrentLocationStoryListBuildable { get }
     var searchResultBuilder: SearchResultBuildable { get }
     var storyEditorBuilder: StoryEditorBuildable { get }
-    var storyDeatilBuilder: StoryDetailBuildable { get }
+    var storyDetailBuilder: StoryDetailBuildable { get }
     var searchStorySeeAllBuilder: SearchStorySeeAllBuildable { get }
 }
 
@@ -92,7 +92,7 @@ extension SearchRouter {
     
     func attachStoryDetail(storyId: Int) {
         guard storyDeatilRouter == nil else { return }
-        let router = dependency.storyDeatilBuilder.build(withListener: interactor, storyId: storyId)
+        let router = dependency.storyDetailBuilder.build(withListener: interactor, storyId: storyId)
         attachChild(router)
         storyDeatilRouter = router
         viewController.pushViewController(router.viewControllable, animated: true)


### PR DESCRIPTION
## 🌁 배경
* close #448 
* 최근 활동 쪽 작업이 아직 진행되지 않아 일단 팔로잉 화면 하나만 들어온다고 가정하고 UI 그려놨습니다.
* 추후 작업이 진행되면 StackView+ScrollView 이용해서 붙이겠습니다!
* 홈화면에서 팔로잉 모두보기 버튼을 누를 시 팔로잉 탭을 선택하도록 추가했습니다.
* (참고) 최신순/좋아요순/댓글순 정렬 호출 하는데 값이 동일해서 화면 리로드가 되지 않습니다

## ✅ 수정 내역
* 팔로잉 UI 추가
* 팔로잉 서비스 추가
* 팔로잉 모두보기 라우팅 추가

## 🎇 스크린샷

https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/574f0446-f6c1-4cb9-b940-a13de26e59d1

