### PR TITLE
팔로우/언팔로우 버튼 수정

### DIFF
--- a/client/Targets/Data/Network/Story/Sources/DTO/CommentReadResponseDTO.swift
+++ b/client/Targets/Data/Network/Story/Sources/DTO/CommentReadResponseDTO.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreKit
 import DomainEntities
 
 public struct CommentReadResponseDTO: Decodable {
@@ -49,7 +50,7 @@ public struct CommentReadResponseDTO: Decodable {
                                           authorStatus: UserStatus.allCases[safe: status] ?? .nonFollowing),
                            date: createdAt,
                            mentionedUsers: mentions.map { $0.toDomain() },
-                           content: content)
+                           content: content.withLineBreak)
         }
     }
     

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailInteractor.swift
@@ -107,9 +107,9 @@ private extension StoryDetailInteractor {
                 .onSuccess(on: .main, with: self) { this, _ in
                     this.presenter.didFollow()
                 }
-                .onFailure { error in
-                    Log.make(message: "fail to follow \(userId) with \(error.localizedDescription)",
-                             log: .interactor)
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: "fail to follow \(userId) with \(error.localizedDescription)", log: .interactor)
+                    this.presenter.didUnfollow()
                 }
         }.store(in: cancelBag)
     }
@@ -122,9 +122,9 @@ private extension StoryDetailInteractor {
                 .onSuccess(on: .main, with: self) { this, _ in
                     this.presenter.didUnfollow()
                 }
-                .onFailure { error in
-                    Log.make(message: "fail to unfollow \(userId) with \(error.localizedDescription)",
-                             log: .interactor)
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: "fail to unfollow \(userId) with \(error.localizedDescription)", log: .interactor)
+                    this.presenter.didFollow()
                 }
         }.store(in: cancelBag)
     }


### PR DESCRIPTION
## 🌁 배경
* #417 

## ✅ 수정 내역
* 팔로우/언팔로우 버튼 디자인 수정
* 팔로우/언팔로우 버튼 클릭 시 네트워크 작업 완료 전까지 버튼을 비활성화
* Response line break 수정

## 🎇 스크린샷
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-11-30 at 22 52 38](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/e28be144-4630-4702-b1ab-f58ff1c4b6ca)
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-11-30 at 22 52 33](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/09cf7fd1-a360-4ae1-bba1-a2d1fa2654d5)

