### PR TITLE
지도 스토리 선택 범위 수정

### DIFF
--- a/client/Targets/Presentation/My/Implementations/Sources/MyPage/UserDashboard/MyPageUserDashboardInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyPage/UserDashboard/MyPageUserDashboardInteractor.swift
@@ -73,7 +73,7 @@ private extension MyPageProfile {
             profileImageURL: profileImageURL,
             follower: "\(followerCount)", // 팔로잉 변환 로직 추가
             storyCount: "\(storyCount)",
-            experience: "\(experience)/\(maxExperience)", // 경험치 변환 로직 추가
+            experience: "\((experience * 100) / maxExperience)%",
             temperatureTitle: temperatureFeeling,
             temperature: "\(temperature)℃",
             badgeTitle: mainBadge.emoji + " " + mainBadge.name,

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
@@ -261,9 +261,7 @@ extension SearchViewController: NMFMapViewCameraDelegate, NMFMapViewTouchDelegat
 private extension SearchViewController {
     
     @objc func storyViewDidTap() {
-        print("#### A")
         guard let storyId = storyView.storyID else { return }
-        print("# B: \(storyId)")
         listener?.didTapStory(storyId: storyId)
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
@@ -99,7 +99,6 @@ final class SearchViewController: UIViewController, SearchPresentable, SearchVie
         storyView.layer.borderColor = UIColor.hpGray3.cgColor
         storyView.layer.borderWidth = 1
         storyView.translatesAutoresizingMaskIntoConstraints = false
-        storyView.addTapGesture(target: self, action: #selector(storyViewDidTap))
         return storyView
     }()
     
@@ -225,6 +224,10 @@ extension SearchViewController: SearchMapSelectedViewDelegate, SearchMapStoryVie
         listener?.didTapStoryCreate()
     }
     
+    func searchMapStoryViewDidTap(_ view: SearchMapStoryView, storyId: Int) {
+        listener?.didTapStory(storyId: storyId)
+    }
+    
 }
 
 extension SearchViewController: NMFMapViewCameraDelegate, NMFMapViewTouchDelegate {
@@ -258,7 +261,9 @@ extension SearchViewController: NMFMapViewCameraDelegate, NMFMapViewTouchDelegat
 private extension SearchViewController {
     
     @objc func storyViewDidTap() {
+        print("#### A")
         guard let storyId = storyView.storyID else { return }
+        print("# B: \(storyId)")
         listener?.didTapStory(storyId: storyId)
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapStoryView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapStoryView.swift
@@ -22,6 +22,7 @@ struct SearchMapStoryViewModel {
 
 protocol SearchMapStoryViewDelegate: AnyObject {
     func searchMapStoryViewDidTapCreate(_ view: SearchMapStoryView)
+    func searchMapStoryViewDidTap(_ view: SearchMapStoryView, storyId: Int)
 }
 
 final class SearchMapStoryView: UIView {
@@ -78,6 +79,7 @@ private extension SearchMapStoryView {
     
     func setupViews() {
         backgroundColor = .hpWhite
+        storyView.addTapGesture(target: self, action: #selector(didTap))
         [storyView, createButton].forEach(addSubview)
         
         NSLayoutConstraint.activate([
@@ -95,6 +97,11 @@ private extension SearchMapStoryView {
     
     @objc func createButtonDidTap() {
         delegate?.searchMapStoryViewDidTapCreate(self)
+    }
+    
+    @objc func didTap() {
+        guard let storyID else { return }
+        delegate?.searchMapStoryViewDidTap(self, storyId: storyID)
     }
     
 }


### PR DESCRIPTION
## 🌁 배경
* close #457 
* 지도에서 스토리 상세 탭 되는 영역이 바깥 영역만 되어서 수정했습니다.
* +마이페이지에 경험치 표현하는 방식 변경했습니다 (작은거라 포함했슴다)

## ✅ 수정 내역
* 지도 스토리 상세 터치 영역 수정
* 마이페이지 경험치 로직 변경