### PR TITLE
UserStatus 순서 수정

### DIFF
--- a/client/Targets/Domain/Entities/Sources/User/UserStatus.swift
+++ b/client/Targets/Domain/Entities/Sources/User/UserStatus.swift
@@ -10,6 +10,6 @@ import Foundation
 
 public enum UserStatus: CaseIterable {
     case me
-    case following
     case nonFollowing
+    case following
 }


### PR DESCRIPTION
## 🌁 배경
* #468 
* 서버에서는 non-following이 1번, following이 2번으로 되어있고, client에서는 반대로 되어있는 문제

## ✅ 수정 내역
* UserStatus reorder
