### PR TITLE
Combine Cocoa 추가

### DIFF
--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/ControlPubliser.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/ControlPubliser.swift
@@ -1,0 +1,61 @@
+//
+//  ControlPubliser.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 12/4/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+public struct ControlPubliser<Control: UIControl>: Publisher {
+    
+    public typealias Output = Control
+    public typealias Failure = Never
+    
+    private let control: Control
+    private let event: Control.Event
+    
+    public init(
+        control: Control,
+        event: UIControl.Event
+    ) {
+        self.control = control
+        self.event = event
+    }
+    
+    public func receive<S: Subscriber>(subscriber: S) where S.Failure == Failure, S.Input == Output {
+        let subscription = Subscription(subscriber: subscriber, control: control, event: event)
+        subscriber.receive(subscription: subscription)
+    }
+    
+    
+}
+
+extension ControlPubliser {
+    
+    final class Subscription<S: Subscriber, C: UIControl>: Combine.Subscription where S.Input == C {
+        
+        weak private var control: C?
+        
+        private var subscriber: S?
+        
+        init(subscriber: S, control: C, event: Control.Event) {
+            self.subscriber = subscriber
+            self.control = control
+            control.addTarget(self, action: #selector(processControlEvent), for: event)
+        }
+        
+        func request(_ demand: Subscribers.Demand) {}
+        
+        func cancel() {
+            subscriber = nil
+        }
+        
+        @objc private func processControlEvent() {
+            guard let control else { return }
+            _ = subscriber?.receive(control)
+        }
+    }
+}

--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/ControlPubliser.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/ControlPubliser.swift
@@ -19,7 +19,7 @@ public struct ControlPubliser<Control: UIControl>: Publisher {
     
     public init(
         control: Control,
-        event: UIControl.Event
+        event: Control.Event
     ) {
         self.control = control
         self.event = event
@@ -29,7 +29,6 @@ public struct ControlPubliser<Control: UIControl>: Publisher {
         let subscription = Subscription(subscriber: subscriber, control: control, event: event)
         subscriber.receive(subscription: subscription)
     }
-    
     
 }
 

--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/Publisher+.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/Publisher+.swift
@@ -1,0 +1,24 @@
+//
+//  Combine+.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 12/4/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Combine
+
+public extension Publisher {
+    
+    func with<O: AnyObject>(_ object: O) -> Publishers.CompactMap<Self, (O, Self.Output)> {
+        return compactMap { [weak object] output in
+            guard let object else { return nil }
+            return (object, output)
+        }
+    }
+    
+    func sinkWith<O: AnyObject>(_ object: O) -> Publishers.CompactMap<Self, (O, Self.Output)> {
+        return with(object)
+    }
+    
+}

--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/Publisher+.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/Publisher+.swift
@@ -17,4 +17,10 @@ public extension Publisher {
         }
     }
     
+    func withOnly<O: AnyObject>(_ object: O) -> Publishers.CompactMap<Self, O> {
+        return compactMap { [weak object] _ in
+            return object
+        }
+    }
+    
 }

--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/Publisher+.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/Publisher+.swift
@@ -17,8 +17,4 @@ public extension Publisher {
         }
     }
     
-    func sinkWith<O: AnyObject>(_ object: O) -> Publishers.CompactMap<Self, (O, Self.Output)> {
-        return with(object)
-    }
-    
 }

--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/UIButton+Combine.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/UIButton+Combine.swift
@@ -1,0 +1,20 @@
+//
+//  UIButton+Combine.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 12/4/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+public extension UIButton {
+    
+    var tapPublisher: AnyPublisher<Void, Never> {
+        return controlPublisher(.touchUpInside)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+    
+}

--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/UIControl+Combine.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/UIControl+Combine.swift
@@ -1,0 +1,18 @@
+//
+//  UIControl+Combine.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 12/4/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+public extension UIControl {
+    
+    func controlPublisher(_ event: Event) -> ControlPubliser<UIControl> {
+        return ControlPubliser(control: self, event: event)
+    }
+    
+}

--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/UITextField+Combine.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/UITextField+Combine.swift
@@ -1,0 +1,23 @@
+//
+//  UITextField+Combine.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 12/4/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+public extension UITextField {
+    
+    var textPublisher: AnyPublisher<String, Never> {
+        return controlPublisher(.editingChanged)
+            .with(self)
+            .map { this, _ in 
+                return this.text ?? ""
+            }
+            .eraseToAnyPublisher()
+    }
+    
+}

--- a/client/Targets/Core/CoreKit/Sources/CombineUtil/UITextView+Combine.swift
+++ b/client/Targets/Core/CoreKit/Sources/CombineUtil/UITextView+Combine.swift
@@ -1,0 +1,68 @@
+//
+//  UITextView+Combine.swift
+//  CoreKit
+//
+//  Created by 홍성준 on 12/4/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+public extension UITextView {
+    
+    var changePublisher: AnyPublisher<String, Never> {
+        self.delegate = self
+        return NotificationCenter.default.publisher(for: .changePublisher, object: self)
+            .with(self)
+            .map { this, _ in
+                return this.text
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    var beginEditingPublisher: AnyPublisher<String, Never> {
+        self.delegate = self
+        return NotificationCenter.default.publisher(for: .beginEditingPublisher, object: self)
+            .with(self)
+            .map { this, _ in
+                return this.text
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    var endEditingPublisher: AnyPublisher<String, Never> {
+        self.delegate = self
+        return NotificationCenter.default.publisher(for: .endEditingPublisher, object: self)
+            .with(self)
+            .map { this, _ in
+                return this.text
+            }
+            .eraseToAnyPublisher()
+    }
+    
+}
+
+extension UITextView: UITextViewDelegate {
+    
+    public func textViewDidBeginEditing(_ textView: UITextView) {
+        NotificationCenter.default.post(name: .beginEditingPublisher, object: textView)
+    }
+    
+    public func textViewDidChange(_ textView: UITextView) {
+        NotificationCenter.default.post(name: .changePublisher, object: textView)
+    }
+    
+    public func textViewDidEndEditing(_ textView: UITextView) {
+        NotificationCenter.default.post(name: .endEditingPublisher, object: textView)
+    }
+    
+}
+
+private extension Notification.Name {
+    
+    static let changePublisher = Notification.Name("changePublisher")
+    static let beginEditingPublisher = Notification.Name("beginEditingPublisher")
+    static let endEditingPublisher = Notification.Name("endEditingPublisher")
+    
+}

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignIn/SignInViewController.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignIn/SignInViewController.swift
@@ -8,6 +8,8 @@
 
 import ModernRIBs
 import UIKit
+import Combine
+import CoreKit
 import DesignKit
 
 protocol SignInPresentableListener: AnyObject {
@@ -19,10 +21,11 @@ public final class SignInViewController: UIViewController, SignInPresentable, Si
 
     weak var listener: SignInPresentableListener?
     
+    private var cancellables = Set<AnyCancellable>()
+    
     private lazy var naverLoginButton: SignInButton = {
         let button = SignInButton()
         button.setup(type: .naver)
-        button.addTarget(self, action: #selector(naverButtonDidTap), for: .touchUpInside)
         button.layer.cornerRadius = 16
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
@@ -31,7 +34,6 @@ public final class SignInViewController: UIViewController, SignInPresentable, Si
     private lazy var appleLoginButton: SignInButton = {
         let button = SignInButton()
         button.setup(type: .apple)
-        button.addTarget(self, action: #selector(appleButtonDidTap), for: .touchUpInside)
         button.layer.cornerRadius = 16
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
@@ -47,11 +49,24 @@ public final class SignInViewController: UIViewController, SignInPresentable, Si
     public override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
+        bind()
     }
     
 }
 
 private extension SignInViewController {
+    
+    func bind() {
+        naverLoginButton.tapPublisher
+            .withOnly(self)
+            .sink { $0.listener?.naverButtonDidTap() }
+            .store(in: &cancellables)
+        
+        appleLoginButton.tapPublisher
+            .withOnly(self)
+            .sink { $0.listener?.appleButtonDidTap() }
+            .store(in: &cancellables)
+    }
     
     func setupViews() {
         view.backgroundColor = .white
@@ -77,15 +92,4 @@ private extension SignInViewController {
         ])
     }
     
-}
-
-private extension SignInViewController {
-    
-    @objc func naverButtonDidTap() {
-        listener?.naverButtonDidTap()
-    }
-    
-    @objc func appleButtonDidTap() {
-        listener?.appleButtonDidTap()
-    }
 }


### PR DESCRIPTION
## 🌁 배경
* close #474 
* 왜 필요한가?
  * 현재 이벤트가 각각 분리되어있어 해당 ViewController에서의 Output을 보기 어려움
  * 데이터 스트림을 통해 직관적으로 확인할 수 있어 가독성에 좋음

## ✅ 수정 내역
* UIKit Control Publisher 추가
* Combine Unretained 추가
* SignIn Combine 추가

## 📕 리뷰 노트
* with 메소드는 객체를 약한 참조해서 가져옵니다.
* withOnly는 객체를 약한 참조해서 그 객체'만' 가져옵니다
* 샘플로 SignIn에 적용해뒀습니다.
```swift
func bind() {
    naverLoginButton.tapPublisher
        .withOnly(self)
        .sink { $0.listener?.naverButtonDidTap() }
        .store(in: &cancellables)

    appleLoginButton.tapPublisher
        .withOnly(self)
        .sink { $0.listener?.appleButtonDidTap() }
        .store(in: &cancellables)
}
```

* [참조](https://github.com/CombineCommunity/CombineCocoa)
