### PR TITLE
likebutton 이미지 눌렸을 때 채우도록 변경

### DIFF
--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/ImageCountButton.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/ImageCountButton.swift
@@ -12,12 +12,22 @@ final class ImageCountButton: UIButton {
 
     enum ButtonType {
         case like
+        case liked
         case comment
         
         var imageName: String {
             switch self {
             case .comment: "bubble"
             case .like: "heart"
+            case .liked: "heart.fill"
+            }
+        }
+        
+        var color: UIColor {
+            switch self {
+            case .comment: return .hpBlack
+            case .like: return .hpBlack
+            case .liked: return .hpRed1
             }
         }
     }
@@ -62,17 +72,12 @@ final class ImageCountButton: UIButton {
     
     func setup(type: ButtonType) {
         typeImageView.image = UIImage(systemName: type.imageName)
-        countLabel.text = "0"
-        
+        typeImageView.tintColor = type.color
+        countLabel.textColor = type.color
     }
     
     func setup(count: Int) {
         countLabel.text = String(count)
-    }
-    
-    func setup(color: UIColor) {
-        typeImageView.tintColor = color
-        countLabel.textColor = color
     }
 
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/StoryHeaderView.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/Components/StoryHeaderView.swift
@@ -90,14 +90,14 @@ final class StoryHeaderView: UIView {
         isLiked = true
         likeButton.setup(count: count)
         likeButton.isUserInteractionEnabled = true
-        likeButton.setup(color: .hpRed1)
+        likeButton.setup(type: .liked)
     }
     
     func didUnlike(count: Int) {
         isLiked = false
         likeButton.setup(count: count)
         likeButton.isUserInteractionEnabled = true
-        likeButton.setup(color: .hpBlack)
+        likeButton.setup(type: .like)
     }
     
     func didFailToLike() {
@@ -132,9 +132,9 @@ private extension StoryHeaderView {
         switch author {
         case .me:
             likeButton.isUserInteractionEnabled = false
-            likeButton.setup(color: .hpRed1)
+            likeButton.setup(type: .liked)
         case .following, .nonFollowing:
-            likeButton.setup(color: (likeStatus ? .hpRed1 : .hpBlack))
+            likeButton.setup(type: (likeStatus ? .liked : .like))
         }
         isLiked = likeStatus
         likeButton.setup(count: likeCount)


### PR DESCRIPTION
## 🌁 배경
* #507

## ✅ 수정 내역
* likebutton 이미지 눌렸을 때 채우도록 변경

## 🎇 스크린샷
* 
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-12-05 at 11 06 54](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/a8d03eeb-4ae9-428d-b8dd-2528e3c4927d)

