### PR TITLE
스토리 삭제

### DIFF
--- a/client/Targets/Data/Network/Story/Sources/DTO/StoryDeleteRequestDTO.swift
+++ b/client/Targets/Data/Network/Story/Sources/DTO/StoryDeleteRequestDTO.swift
@@ -1,0 +1,19 @@
+//
+//  StoryDeleteRequestDTO.swift
+//  StoryAPI
+//
+//  Created by jungmin lim on 12/5/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public struct StoryDeleteRequestDTO: Encodable {
+    
+    let storyId: Int
+    
+    public init(storyId: Int) {
+        self.storyId = storyId
+    }
+    
+}

--- a/client/Targets/Data/Network/Story/Sources/StoryAPI.swift
+++ b/client/Targets/Data/Network/Story/Sources/StoryAPI.swift
@@ -16,6 +16,7 @@ import NetworkAPIKit
 public enum StoryAPI {
     case metaData
     case newStory(StoryContent)
+    case deleteStory(Int)
     case storyDetail(Int)
     case follow(Int)
     case unfollow(Int)
@@ -35,6 +36,7 @@ extension StoryAPI: Target {
         switch self {
         case .metaData: return "/story/meta"
         case .newStory: return "/story/create"
+        case .deleteStory: return "/story/delete"
         case .storyDetail: return "/story/detail"
         case .follow, .unfollow: return "/user/follow"
         case .readComment: return "/comment/read"
@@ -48,6 +50,7 @@ extension StoryAPI: Target {
         switch self {
         case .metaData: return .get
         case .newStory: return .post
+        case .deleteStory: return .delete
         case .storyDetail: return .get
         case .follow: return .post
         case .unfollow: return .delete
@@ -66,25 +69,31 @@ extension StoryAPI: Target {
         switch self {
         case .metaData:
             return .plain
+            
         case .newStory(let content):
             let request = NewStoryRequestDTO(storyContent: content)
             let mediaList = content.images.map { imageData in
                 return Media(data: imageData, type: .jpeg, key: "images")
             }
-            
             return .multipart(MultipartFormData(data: request, mediaList: mediaList))
+            
+        case .deleteStory(let storyId):
+            return .url(parameters: StoryDeleteRequestDTO(storyId: storyId).parameters())
+            
         case .storyDetail(let storyId):
             let request = StoryDetailRequestDTO(storyId: storyId)
-            
             return .url(parameters: request.parameters())
+            
         case .follow(let userId), .unfollow(let userId):
             return .json(FollowRequestDTO(followId: userId))
+            
         case .readComment(let storyId):
             let request = CommentReadRequestDTO(storyId: storyId)
-            
             return .url(parameters: request.parameters())
+            
         case .newComment(let content):
             return .json(NewCommentRequestDTO(content: content))
+            
         case .like(let storyId), .unlike(let storyId):
             return .url(parameters: StoryLikeRequestDTO(storyId: storyId).parameters())
         }

--- a/client/Targets/Data/Repositories/Sources/StoryRepository.swift
+++ b/client/Targets/Data/Repositories/Sources/StoryRepository.swift
@@ -35,6 +35,11 @@ public final class StoryRepository: StoryRepositoryInterface {
         return request.map { $0.toDomain() }
     }
     
+    public func requestDeleteStory(storyId: Int) async -> Result<Void, Error> {
+        let target = StoryAPI.deleteStory(storyId)
+        return await session.request(target)
+    }
+    
     public func requestStoryDetail(storyId: Int) async -> Result<Story, Error> {
         let target = StoryAPI.storyDetail(storyId)
         let request: Result<StoryDetailResponseDTO, Error> = await session.request(target)

--- a/client/Targets/DesignSystem/DesignKit/Sources/Views/NavigationViewButtonType.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/Views/NavigationViewButtonType.swift
@@ -14,6 +14,7 @@ public enum NavigationViewButtonType {
     case home
     case setting
     case edit
+    case delete
     case none
 }
 
@@ -32,6 +33,8 @@ extension NavigationViewButtonType {
             return UIImage(systemName: "gearshape", withConfiguration: config)
         case .edit:
             return UIImage(systemName: "pencil", withConfiguration: config)
+        case .delete:
+            return UIImage(systemName: "trash", withConfiguration: config)
         case .none:
             return nil
         }

--- a/client/Targets/Domain/Interfaces/Sources/Repository/StoryRepositoryInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/Repository/StoryRepositoryInterface.swift
@@ -14,6 +14,7 @@ public protocol StoryRepositoryInterface: AnyObject {
     
     func requestMetaData() async -> Result<([StoryCategory], [Badge]), Error>
     func requestCreateStory(storyContent: StoryContent) async -> Result<Story, Error>
+    func requestDeleteStory(storyId: Int) async -> Result<Void, Error>
     func requestStoryDetail(storyId: Int) async -> Result<Story, Error>
     func requestFollow(userId: Int) async -> Result<Void, Error>
     func requestUnfollow(userId: Int) async -> Result<Void, Error>

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/StoryUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/StoryUseCaseInterface.swift
@@ -15,6 +15,7 @@ public protocol StoryUseCaseInterface: AnyObject {
     func requestAddress(of location: Location) async -> Result<String?, Error>
     func requestMetaData() async -> Result<([StoryCategory], [Badge]), Error>
     func requestCreateStory(storyContent: StoryContent) async -> Result<Story, Error>
+    func requestDeleteStory(storyId: Int) async -> Result<Void, Error>
     func requestStoryDetail(storyId: Int) async -> Result<Story, Error>
     func requestFollow(userId: Int) async -> Result<Void, Error>
     func requestUnfollow(userId: Int) async -> Result<Void, Error>

--- a/client/Targets/Domain/UseCases/Sources/StoryUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/StoryUseCase.swift
@@ -40,6 +40,10 @@ public final class StoryUseCase: StoryUseCaseInterface {
         return await repository.requestCreateStory(storyContent: storyContent)
     }
     
+    public func requestDeleteStory(storyId: Int) async -> Result<Void, Error> {
+        return await repository.requestDeleteStory(storyId: storyId)
+    }
+    
     public func requestStoryDetail(storyId: Int) async -> Result<Story, Error> {
         return await repository.requestStoryDetail(storyId: storyId)
     }

--- a/client/Targets/Presentation/Following/Implementations/Sources/FollowingHome/FollowingHomeInteractor.swift
+++ b/client/Targets/Presentation/Following/Implementations/Sources/FollowingHome/FollowingHomeInteractor.swift
@@ -47,4 +47,7 @@ final class FollowingHomeInteractor: PresentableInteractor<FollowingHomePresenta
         router?.detachStoryDetail()
     }
     
+    func storyDidDelete() {
+        router?.detachStoryDetail()
+    }
 }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HomeInteractor.swift
@@ -108,4 +108,8 @@ final class HomeInteractor: PresentableInteractor<HomePresentable>, HomeInteract
         router?.detachStoryDetail()
     }
     
+    func storyDidDelete() {
+        router?.detachStoryDetail()
+    }
+    
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/MyPage/MyPageInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyPage/MyPageInteractor.swift
@@ -125,4 +125,8 @@ final class MyPageInteractor: PresentableInteractor<MyPagePresentable>, MyPageIn
         router?.detachStoryDetail()
     }
     
+    func storyDidDelete() {
+        router?.detachStoryDetail()
+    }
+    
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -97,6 +97,10 @@ final class SearchInteractor: PresentableInteractor<SearchPresentable>,
         router?.detachStoryDetail()
     }
     
+    func storyDidDelete() {
+        router?.detachStoryDetail()
+    }
+    
     func storyDidCreate(_ storyId: Int) {
         router?.detachStoryEditor { [weak self] in
             self?.router?.attachStoryDetail(storyId: storyId)

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailInteractor.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailInteractor.swift
@@ -102,9 +102,26 @@ final class StoryDetailInteractor: PresentableInteractor<StoryDetailPresentable>
         router?.detachComment()
     }
     
+    func deleteButtonDidTap() {
+        requestDeleteStory()
+    }
 }
 
 private extension StoryDetailInteractor {
+    
+    func requestDeleteStory() {
+        Task { [weak self] in
+            guard let self else { return }
+            await dependency.storyUseCase
+                .requestDeleteStory(storyId: dependency.storyId)
+                .onSuccess(on: .main, with: self) { this, _ in
+                    this.listener?.storyDidDelete()
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: "failed to delete story with \(error.localizedDescription)", log: .interactor)
+                }
+        }.store(in: cancelBag)
+    }
     
     func requestFollow(_ userId: Int) {
         Task { [weak self] in

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryDetail/StoryDetailViewController.swift
@@ -21,6 +21,7 @@ protocol StoryDetailPresentableListener: AnyObject {
     func followButtonDidTap(userId: Int, userStatus: UserStatus)
     func likeButtonDidTap(state: Bool)
     func commentButtonDidTap()
+    func deleteButtonDidTap()
 }
 
 struct StoryDetailViewModel {
@@ -68,6 +69,7 @@ final class StoryDetailViewController: BaseViewController, StoryDetailPresentabl
     private let mapView = StoryMapView()
     
     func setup(model: StoryDetailViewModel) {
+        setupNavigationView(model.userProfileViewModel.userStatus)
         simpleUserProfileView.setup(model: model.userProfileViewModel)
         storyHeaderView.setup(model: model.headerViewModel)
         storyImagesView.updateImages(model.images)
@@ -182,6 +184,12 @@ final class StoryDetailViewController: BaseViewController, StoryDetailPresentabl
         mapView.translatesAutoresizingMaskIntoConstraints = false
     }
     
+    func setupNavigationView(_ userStatus: UserStatus) {
+        if case .me = userStatus {
+            navigationView.setup(model: .init(title: "", leftButtonType: .back, rightButtonTypes: [.delete]))
+        }
+    }
+    
     override func bind() {
         
     }
@@ -192,7 +200,18 @@ final class StoryDetailViewController: BaseViewController, StoryDetailPresentabl
 extension StoryDetailViewController: NavigationViewDelegate {
    
     func navigationViewButtonDidTap(_ view: NavigationView, type: NavigationViewButtonType) {
-        listener?.storyDetailDidTapClose()
+        switch type {
+        case .back:
+            listener?.storyDetailDidTapClose()
+        case .delete:
+            listener?.deleteButtonDidTap()
+        case .home:
+            break
+        case .close, .edit, .setting, .none:
+            break
+        }
+        
+        
     }
 
 }

--- a/client/Targets/Presentation/Story/Interfaces/Sources/StoryInterface.swift
+++ b/client/Targets/Presentation/Story/Interfaces/Sources/StoryInterface.swift
@@ -15,6 +15,7 @@ public protocol StoryDetailBuildable: Buildable {
 
 public protocol StoryDetailListener: AnyObject {
     func storyDetailDidTapClose()
+    func storyDidDelete()
 }
 
 public protocol StoryEditorBuildable: Buildable {


### PR DESCRIPTION
## 🌁 배경
* #510 

## ✅ 수정 내역
* 스토리 삭제 기능 구현 및 삭제 완료 interface 추가

## 📕 리뷰 노트
* 스토리 삭제 완료 후 refresh가 필요합니다.
  * 스토리 상세와 연결된 interactor들에 `storyDidDelete` method 추가했습니다.
  * pull to refresh 구현 하면서 `stodyDidDelete` method에 넣어주시면 감사하겠습니다 :)

## 🎇 스크린샷
* 
![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-12-05 at 15 51 20](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/13cba0cc-3b90-4f6e-95d8-76d8fad9939b)
