### PR TITLE
현재 위치 스토리 리스트 추가

### DIFF
--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListUseCaseInterface.swift
@@ -11,4 +11,5 @@ import DomainEntities
 
 public protocol SearchCurrentLocationStoryListUseCaseInterface {
     func fetchRecommendPlace(lat: Double, lng: Double) async -> Result<[Place], Error>
+    func requestLocality(lat: Double, lng: Double) async -> String?
 }

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListUseCaseInterface.swift
@@ -7,5 +7,8 @@
 //
 
 import Foundation
+import DomainEntities
 
-public protocol SearchCurrentLocationStoryListUseCaseInterface {}
+public protocol SearchCurrentLocationStoryListUseCaseInterface {
+    func fetchRecommendPlace(lat: Double, lng: Double) async -> Result<[Place], Error>
+}

--- a/client/Targets/Domain/UseCases/Sources/SearchUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/SearchUseCase.swift
@@ -75,4 +75,8 @@ public final class SearchUseCase: SearchUseCaseInterface {
         await repository.fetchSearchLocal(searchText: query)
     }
     
+    public func requestLocality(lat: Double, lng: Double) async -> String? {
+        await locationService.requestLocality(lat: lat, lng: lng)
+    }
+    
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/MyPage/MyPageInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyPage/MyPageInteractor.swift
@@ -36,7 +36,7 @@ protocol MyPageInteractorDependency: AnyObject {
 }
 
 final class MyPageInteractor: PresentableInteractor<MyPagePresentable>, MyPageInteractable, MyPagePresentableListener {
-
+    
     weak var router: MyPageRouting?
     weak var listener: MyPageListener?
     
@@ -123,6 +123,10 @@ final class MyPageInteractor: PresentableInteractor<MyPagePresentable>, MyPageIn
     
     func storyDetailDidTapClose() {
         router?.detachStoryDetail()
+    }
+    
+    func storyDidDelete() {
+        
     }
     
     // MARK: UpdateUser

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListBuilder.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListBuilder.swift
@@ -13,15 +13,21 @@ protocol SearchCurrentLocationStoryListDependency: Dependency {
     var searchCurrentLocationStoryListUseCase: SearchCurrentLocationStoryListUseCaseInterface { get }
 }
 
-final class SearchCurrentLocationStoryListComponent: Component<SearchCurrentLocationStoryListDependency>, SearchCurrentLocationStoryListInteractorDependency {
-    
+final class SearchCurrentLocationStoryListComponent: Component<SearchCurrentLocationStoryListDependency>, 
+                                                        SearchCurrentLocationStoryListInteractorDependency {
     var searchCurrentLocationStoryListUseCase: SearchCurrentLocationStoryListUseCaseInterface { dependency.searchCurrentLocationStoryListUseCase }
+    let location: SearchMapLocation
+    
+    init(dependency: SearchCurrentLocationStoryListDependency, location: SearchMapLocation) {
+        self.location = location
+        super.init(dependency: dependency)
+    }
 }
 
 // MARK: - Builder
 
 protocol SearchCurrentLocationStoryListBuildable: Buildable {
-    func build(withListener listener: SearchCurrentLocationStoryListListener) -> SearchCurrentLocationStoryListRouting
+    func build(withListener listener: SearchCurrentLocationStoryListListener, location: SearchMapLocation) -> SearchCurrentLocationStoryListRouting
 }
 
 final class SearchCurrentLocationStoryListBuilder: Builder<SearchCurrentLocationStoryListDependency>, SearchCurrentLocationStoryListBuildable {
@@ -30,8 +36,8 @@ final class SearchCurrentLocationStoryListBuilder: Builder<SearchCurrentLocation
         super.init(dependency: dependency)
     }
 
-    func build(withListener listener: SearchCurrentLocationStoryListListener) -> SearchCurrentLocationStoryListRouting {
-        let component = SearchCurrentLocationStoryListComponent(dependency: dependency)
+    func build(withListener listener: SearchCurrentLocationStoryListListener, location: SearchMapLocation) -> SearchCurrentLocationStoryListRouting {
+        let component = SearchCurrentLocationStoryListComponent(dependency: dependency, location: location)
         let viewController = SearchCurrentLocationStoryListViewController()
         let interactor = SearchCurrentLocationStoryListInteractor(presenter: viewController, dependency: component)
         interactor.listener = listener

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListInteractor.swift
@@ -50,6 +50,7 @@ final class SearchCurrentLocationStoryListInteractor: PresentableInteractor<Sear
 
     override func didBecomeActive() {
         super.didBecomeActive()
+        requestLocality()
         fetchPlaces()
     }
 
@@ -89,6 +90,22 @@ final class SearchCurrentLocationStoryListInteractor: PresentableInteractor<Sear
             )
         }
         presenter.setup(models: models)
+    }
+    
+    private func requestLocality() {
+        Task { [weak self] in
+            guard let self else { return }
+            let locality = await dependency.searchCurrentLocationStoryListUseCase
+                .requestLocality(lat: dependency.location.lat, lng: dependency.location.lng)
+            
+            await MainActor.run { [weak self] in
+                self?.performAfterRequestLocality(locality)
+            }
+        }.store(in: cancelBag)
+    }
+    
+    private func performAfterRequestLocality(_ locality: String?) {
+        presenter.updateLocation(locality ?? "현재 위치")
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListViewController.swift
@@ -11,7 +11,7 @@ import DesignKit
 import ModernRIBs
 
 protocol SearchCurrentLocationStoryListPresentableListener: AnyObject {
-    func didTapItem(model: SearchCurrentLocationStoryListCellModel)
+    func didTap(at indexPath: IndexPath)
 }
 
 final class SearchCurrentLocationStoryListViewController: UIViewController, SearchCurrentLocationStoryListPresentable, SearchCurrentLocationStoryListViewControllable {
@@ -25,8 +25,9 @@ final class SearchCurrentLocationStoryListViewController: UIViewController, Sear
     }
     
     private lazy var tableView: UITableView = {
-        let tableView = UITableView()
+        let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.register(SearchCurrentLocationStoryListCell.self)
+        tableView.backgroundColor = .hpWhite
         tableView.delegate = self
         tableView.dataSource = self
         tableView.translatesAutoresizingMaskIntoConstraints = false
@@ -103,8 +104,7 @@ extension SearchCurrentLocationStoryListViewController: UITableViewDataSource {
 extension SearchCurrentLocationStoryListViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let model = models[safe: indexPath.row] else { return }
-        listener?.didTapItem(model: model)
+        listener?.didTap(at: indexPath)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/SearchCurrentLocationStoryListViewController.swift
@@ -7,14 +7,16 @@
 //
 
 import UIKit
+import CoreKit
 import DesignKit
 import ModernRIBs
+import BasePresentation
 
 protocol SearchCurrentLocationStoryListPresentableListener: AnyObject {
     func didTap(at indexPath: IndexPath)
 }
 
-final class SearchCurrentLocationStoryListViewController: UIViewController, SearchCurrentLocationStoryListPresentable, SearchCurrentLocationStoryListViewControllable {
+final class SearchCurrentLocationStoryListViewController: BaseViewController, SearchCurrentLocationStoryListPresentable, SearchCurrentLocationStoryListViewControllable {
     
     weak var listener: SearchCurrentLocationStoryListPresentableListener?
     
@@ -24,36 +26,20 @@ final class SearchCurrentLocationStoryListViewController: UIViewController, Sear
         static let topOffset: CGFloat = 20
     }
     
-    private lazy var tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .grouped)
-        tableView.register(SearchCurrentLocationStoryListCell.self)
-        tableView.backgroundColor = .hpWhite
-        tableView.delegate = self
-        tableView.dataSource = self
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        return tableView
-    }()
-    
-    private let locationLabel: UILabel = {
-       let label = UILabel()
-        label.font = .bodyBold
-        label.text = "현재 위치"
-        label.textAlignment = .center
-        label.textColor = .hpBlack
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        setupViews()
-    }
+    private let tableView = UITableView(frame: .zero, style: .grouped)
+    private let locationLabel = UILabel()
+    private let emptyContainerView = UIView()
+    private let emptyView = SearchCurrentLocationStoryEmptyView()
     
     func updateLocation(_ location: String) {
         locationLabel.text = location
     }
     
     func setup(models: [SearchCurrentLocationStoryListCellModel]) {
+        if models.isEmpty {
+            emptyContainerView.isHidden = false
+            return
+        }
         self.models = models
         tableView.reloadData()
     }
@@ -63,23 +49,59 @@ final class SearchCurrentLocationStoryListViewController: UIViewController, Sear
         tableView.reloadData()
     }
     
-}
-
-private extension SearchCurrentLocationStoryListViewController {
-
-    func setupViews() {
-        view.backgroundColor = .hpWhite
-        [locationLabel, tableView].forEach { view.addSubview($0) }
+    override func setupLayout() {
+        [locationLabel, tableView, emptyContainerView].forEach(view.addSubview)
+        emptyContainerView.addSubview(emptyView)
+        
         NSLayoutConstraint.activate([
             locationLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constant.topOffset),
-            locationLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            locationLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            locationLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            locationLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             
             tableView.topAnchor.constraint(equalTo: locationLabel.bottomAnchor, constant: Constant.topOffset),
             tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Constants.leadingOffset),
             tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: Constants.traillingOffset),
             tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            
+            emptyContainerView.topAnchor.constraint(equalTo: locationLabel.bottomAnchor),
+            emptyContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            emptyContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            emptyView.centerYAnchor.constraint(equalTo: emptyContainerView.centerYAnchor, constant: -Constant.topOffset),
+            emptyView.leadingAnchor.constraint(equalTo: emptyContainerView.leadingAnchor),
+            emptyView.trailingAnchor.constraint(equalTo: emptyContainerView.trailingAnchor)
         ])
+    }
+    
+    override func setupAttributes() {
+        view.backgroundColor = .hpWhite
+        
+        tableView.do {
+            $0.register(SearchCurrentLocationStoryListCell.self)
+            $0.backgroundColor = .hpWhite
+            $0.delegate = self
+            $0.dataSource = self
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        locationLabel.do {
+            $0.font = .bodyBold
+            $0.text = "현재 위치"
+            $0.textAlignment = .center
+            $0.textColor = .hpBlack
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        emptyContainerView.do {
+            $0.backgroundColor = .hpWhite
+            $0.isHidden = true
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        emptyView.do {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/Views/SearchCurrentLocationStoryEmptyView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/Views/SearchCurrentLocationStoryEmptyView.swift
@@ -1,0 +1,64 @@
+//
+//  SearchCurrentLocationStoryEmptyView.swift
+//  SearchImplementations
+//
+//  Created by 홍성준 on 12/6/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import CoreKit
+import DesignKit
+
+final class SearchCurrentLocationStoryEmptyView: UIView {
+    
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        setupAttributes()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupLayout()
+        setupAttributes()
+    }
+    
+    private func setupLayout() {
+        [titleLabel, subtitleLabel].forEach(addSubview)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
+            subtitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            subtitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            subtitleLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+    private func setupAttributes() {
+        titleLabel.do {
+            $0.text = "스토리가 없어요"
+            $0.font = .bodySemibold
+            $0.textColor = .hpBlack
+            $0.textAlignment = .center
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        subtitleLabel.do {
+            $0.text = "새로운 스토리를 작성해보세요!"
+            $0.font = .captionRegular
+            $0.textColor = .hpBlack
+            $0.textAlignment = .center
+            $0.numberOfLines = 0
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+    
+}

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/Views/SearchCurrentLocationStoryListCell.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchCurrentLocationStoryList/Views/SearchCurrentLocationStoryListCell.swift
@@ -11,21 +11,19 @@ import UIKit
 import BasePresentation
 import DesignKit
 
-public struct SearchCurrentLocationStoryListCellModel {
-    public let thumbnailImageURL: String
-    public let title: String
-    public let likes: Int
-    public let comments: Int
-    public let nickname: String
-    public let profileImageURL: String?
+struct SearchCurrentLocationStoryListCellModel {
+    let thumbnailImageURL: String
+    let title: String
+    let content: String
+    let likes: Int
+    let comments: Int
     
-    public init(thumbnailImageURL: String, title: String, likes: Int, comments: Int, nickname: String, profileImageURL: String?) {
+    init(thumbnailImageURL: String, title: String, content: String, likes: Int, comments: Int) {
         self.thumbnailImageURL = thumbnailImageURL
         self.title = title
+        self.content = content
         self.likes = likes
         self.comments = comments
-        self.nickname = nickname
-        self.profileImageURL = profileImageURL
     }
 }
 
@@ -50,7 +48,15 @@ final class SearchCurrentLocationStoryListCell: UITableViewCell {
     
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .captionSemibold
+        label.font = .bodySemibold
+        label.textColor = .hpBlack
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let contentLabel: UILabel = {
+        let label = UILabel()
+        label.font = .captionRegular
         label.textColor = .hpBlack
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -60,24 +66,6 @@ final class SearchCurrentLocationStoryListCell: UITableViewCell {
        let storySmallCommentView = StorySmallCommentView()
         storySmallCommentView.translatesAutoresizingMaskIntoConstraints = false
         return storySmallCommentView
-    }()
-    
-    private let profileImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.backgroundColor = .hpGray3
-        imageView.clipsToBounds = true
-        imageView.layer.cornerRadius = Constant.profileImageWidth / 2
-        imageView.contentMode = .scaleAspectFill
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-    
-    private let nicknameLabel: UILabel = {
-        let label = UILabel()
-        label.font = .smallRegular
-        label.textColor = .hpBlack
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
     }()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -95,21 +83,17 @@ final class SearchCurrentLocationStoryListCell: UITableViewCell {
         thumbnailImageView.image = nil
         titleLabel.text = ""
         storySmallCommentView.setup(likes: 0, comments: 0)
-        nicknameLabel.text = ""
-        profileImageView.image = nil
     }
     
     deinit {
         thumbnailImageView.cancel()
-        profileImageView.cancel()
     }
     
     func setup(model: SearchCurrentLocationStoryListCellModel) {
         thumbnailImageView.load(from: model.thumbnailImageURL)
         titleLabel.text = model.title
+        contentLabel.text = model.content
         storySmallCommentView.setup(likes: model.likes, comments: model.comments)
-        nicknameLabel.text = model.nickname
-        profileImageView.load(from: model.profileImageURL)
     }
 }
 
@@ -118,33 +102,27 @@ private extension SearchCurrentLocationStoryListCell {
     func setupViews() {
         selectionStyle = .none
         
-        [thumbnailImageView, storySmallCommentView, titleLabel, profileImageView, nicknameLabel].forEach(addSubview)
+        [thumbnailImageView, storySmallCommentView, titleLabel, contentLabel].forEach(contentView.addSubview)
         
         NSLayoutConstraint.activate([
-            thumbnailImageView.topAnchor.constraint(equalTo: topAnchor, constant: Constant.spacing),
-            thumbnailImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            thumbnailImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            thumbnailImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constant.spacing),
+            thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             thumbnailImageView.widthAnchor.constraint(equalToConstant: Constant.imageWidth),
             thumbnailImageView.heightAnchor.constraint(equalToConstant: Constant.imageHeight),
             
             storySmallCommentView.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: 10),
-            storySmallCommentView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            storySmallCommentView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            
+            storySmallCommentView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            storySmallCommentView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             
             titleLabel.topAnchor.constraint(equalTo: storySmallCommentView.bottomAnchor, constant: 5),
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
-            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             
-            profileImageView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
-            profileImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            profileImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constant.spacing),
-            profileImageView.widthAnchor.constraint(equalToConstant: Constant.profileImageWidth),
-            profileImageView.heightAnchor.constraint(equalToConstant: Constant.profileImageHeight),
-            
-            nicknameLabel.centerYAnchor.constraint(equalTo: profileImageView.centerYAnchor),
-            nicknameLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: 5),
-            nicknameLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
+            contentLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
+            contentLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            contentLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            contentLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Constant.spacing),
         ])
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -15,7 +15,7 @@ import BasePresentation
 import CoreLocation
 
 protocol SearchRouting: ViewableRouting {
-    func attachSearchCurrentLocation()
+    func attachSearchCurrentLocation(location: SearchMapLocation)
     func detachSearchCurrentLocation()
     func attachSearchResult()
     func detachSearchResult()
@@ -111,6 +111,11 @@ final class SearchInteractor: PresentableInteractor<SearchPresentable>,
         router?.detachStoryEditor(nil)
     }
     
+    func searchCurrentLocationStoryListDidTapStory(_ storyId: Int) {
+        router?.detachSearchCurrentLocation()
+        router?.attachStoryDetail(storyId: storyId)
+    }
+    
 }
 
 // MARK: - PresentableListener
@@ -118,7 +123,8 @@ final class SearchInteractor: PresentableInteractor<SearchPresentable>,
 extension SearchInteractor: SearchPresentableListener {
     
     func didTapCurrentLocation() {
-        router?.attachSearchCurrentLocation()
+        guard let location = watchingLocation else { return }
+        router?.attachSearchCurrentLocation(location: location)
     }
     
     func didTapSearchTextField() {

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
@@ -57,9 +57,9 @@ final class SearchRouter: ViewableRouter<SearchInteractable, SearchViewControlla
         interactor.router = self
     }
     
-    func attachSearchCurrentLocation() {
+    func attachSearchCurrentLocation(location: SearchMapLocation) {
         guard searchCurrentLocationRouter == nil else { return }
-        let router = dependency.searchCurrentLocationBuilder.build(withListener: interactor)
+        let router = dependency.searchCurrentLocationBuilder.build(withListener: interactor, location: location)
         attachChild(router)
         router.viewControllable.uiviewController.presentationController?.delegate = interactor.presentationAdapter
         viewController.present(router.viewControllable, animated: true)
@@ -68,7 +68,7 @@ final class SearchRouter: ViewableRouter<SearchInteractable, SearchViewControlla
     
     func detachSearchCurrentLocation() {
         guard let router = searchCurrentLocationRouter else { return }
-        popRouter(router, animated: true)
+        dismissRouter(router, animated: true)
         searchCurrentLocationRouter = nil
     }
     


### PR DESCRIPTION
## 🌁 배경
* close #542 
* 기존 UI랑 변경된 사항이 있습니다.
  * 기존 UI는 스토리 작성자를 나타내는데 Response에 유저 정보가 없어서 그냥 없애고 스토리 상세 내용 1줄 나오도록 변경했습니다.
* 현재 위치 정보가 모달이라서 push하기 애매해서 모달 창 내리고 스토리 상세 push하도록 하였습니다.

## ✅ 수정 내역
* 현재 위치 스토리 리스트 추가
* 현재 위치 스토리 리스트 라우팅 (스토리 상세) 추가

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/2c259461-f2eb-4c53-a70b-c7925b3bd957

