### PR TITLE
지도 클러스터링 추가

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
@@ -121,7 +121,11 @@ final class AppRootComponent: Component<AppRootDependency>,
         self.userProfileUseCase = self.myPageUseCase
         
         let searchNetworkProvider = AppRootComponent.generateNetworkProvider(isDebug: false, protocols: [SearchURLProtocol.self])
-        self.searchUseCase = SearchUseCase(repository: SearchRepository(session: searchNetworkProvider), locationService: locationService)
+        self.searchUseCase = SearchUseCase(
+            repository: SearchRepository(session: searchNetworkProvider),
+            locationService: locationService,
+            clusteringService: ClusteringService()
+        )
         
         let followingNetworkProvider = AppRootComponent.generateNetworkProvider(isDebug: false, protocols: [])
         self.followingUseCase = FollowingUseCase(repository: FollowingRepository(session: followingNetworkProvider))

--- a/client/Targets/Data/Repositories/Sources/ClusteringOperation.swift
+++ b/client/Targets/Data/Repositories/Sources/ClusteringOperation.swift
@@ -1,0 +1,120 @@
+//
+//  ClusteringOperation.swift
+//  DataRepositories
+//
+//  Created by 홍성준 on 12/6/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import DomainEntities
+
+final class ClusteringOperation: Operation {
+    
+    private let bound: LocationBound
+    private let places: [Place]
+    private let sliceLat: Int
+    private let sliceLng: Int
+    
+    var clusters: [Cluster]?
+    
+    init(bound: LocationBound, places: [Place], sliceLat: Int, sliceLng: Int) {
+        self.bound = bound
+        self.places = places
+        self.sliceLat = sliceLat
+        self.sliceLng = sliceLng
+        super.init()
+    }
+    
+    override func main() {
+        guard !isCancelled else { return }
+        guard let placeBound = makePlaceBound(places: places) else { return }
+        self.clusters = makeCluster(bound: bound, placeBound: placeBound, places: places)
+    }
+    
+    private func makePlaceBound(places: [Place]) -> LocationBound? {
+        guard let minLat = places.map(\.lat).min(),
+              let maxLat = places.map(\.lat).max(),
+              let minLng = places.map(\.lng).min(),
+              let maxLng = places.map(\.lng).max()
+        else {
+            return nil
+        }
+        
+        return .init(
+            southWest: .init(lat: minLat, lng: minLng),
+            northEast: .init(lat: maxLat, lng: maxLng)
+        )
+    }
+    
+    // TODO: - FullBound 영점 조절
+    
+    private func makeCluster(
+        bound: LocationBound,
+        placeBound: LocationBound,
+        places: [Place]
+    ) -> [Cluster] {
+        let latScope = (bound.northEast.lat - bound.southWest.lat) / Double(sliceLat)
+        let lngScope = (bound.northEast.lng - bound.southWest.lng) / Double(sliceLng)
+//        let fullBound = makeFullBound(bound: bound, placeBound: placeBound)
+        
+        var clusters = makeInitialClusters(
+            fullBound: placeBound,
+            latScope: latScope,
+            lngScope: lngScope
+        )
+        
+        for place in places {
+        inner: for (index, cluster) in clusters.enumerated() {
+                if cluster.isValidRange(place) {
+                    clusters[index].places.append(place)
+                    break inner
+                }
+            }
+        }
+        
+        return clusters
+    }
+    
+    private func makeInitialClusters(fullBound bound: LocationBound, latScope: Double, lngScope: Double) -> [Cluster] {
+        var currentLat = bound.southWest.lat
+        var currentLng = bound.southWest.lng
+        var clusters: [Cluster] = []
+        
+        while currentLng < bound.northEast.lng {
+            if currentLat >= bound.northEast.lat {
+                currentLat = bound.southWest.lat
+                currentLng += lngScope
+            }
+            
+            let cluster = Cluster(bound: .init(
+                southWest: .init(lat: currentLat, lng: currentLng),
+                northEast: .init(lat: currentLat + latScope, lng: currentLng + lngScope)
+            ))
+            clusters.append(cluster)
+            currentLat += latScope
+        }
+        return clusters
+    }
+    
+    private func makeFullBound(bound: LocationBound, placeBound: LocationBound) -> LocationBound {
+        let minLat = min(bound.southWest.lat, placeBound.southWest.lat)
+        let minLng = min(bound.southWest.lng, placeBound.southWest.lng)
+        let maxLat = max(bound.northEast.lat, placeBound.northEast.lat)
+        let maxLng = max(bound.northEast.lng, placeBound.northEast.lng)
+        
+        return LocationBound.init(
+            southWest: .init(lat: minLat, lng: minLng),
+            northEast: .init(lat: maxLat, lng: maxLng)
+        )
+    }
+    
+}
+
+private extension Place {
+    
+    var location: LocationCoordinate {
+        return .init(lat: lat, lng: lng)
+    }
+    
+}

--- a/client/Targets/Data/Repositories/Sources/ClusteringService.swift
+++ b/client/Targets/Data/Repositories/Sources/ClusteringService.swift
@@ -1,0 +1,42 @@
+//
+//  ClusteringService.swift
+//  DataRepositories
+//
+//  Created by 홍성준 on 12/6/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import DomainEntities
+import DomainInterfaces
+
+public final class ClusteringService: ClusteringServiceInterface {
+    
+    public var clusteringCompletionBlock: (([Cluster]) -> Void)?
+    
+    private let sliceLat: Int
+    private let sliceLng: Int
+    private let clusteringQueue = OperationQueue()
+    
+    // TODO: - Slice 개수 실험
+    
+    public init(sliceLat: Int = 6, sliceLng: Int = 10) {
+        self.sliceLat = sliceLat
+        self.sliceLng = sliceLng
+    }
+    
+    public func clustering(bound: LocationBound, places: [Place]) {
+        clusteringQueue.cancelAllOperations()
+        let operation = ClusteringOperation(bound: bound, places: places, sliceLat: sliceLat, sliceLng: sliceLng)
+        clusteringQueue.addOperation(operation)
+        
+        operation.completionBlock = { [weak self] in
+            guard let clusters = operation.clusters
+            else {
+                return
+            }
+            self?.clusteringCompletionBlock?(clusters)
+        }
+    }
+    
+}

--- a/client/Targets/Domain/Entities/Sources/Location/Cluster.swift
+++ b/client/Targets/Domain/Entities/Sources/Location/Cluster.swift
@@ -1,0 +1,44 @@
+//
+//  Cluster.swift
+//  DomainEntities
+//
+//  Created by 홍성준 on 12/6/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public struct Cluster {
+    
+    public var center: LocationCoordinate {
+        return places.map { LocationCoordinate(lat: $0.lat, lng: $0.lng) }
+            .reduce(.zero, +) / Double(places.count)
+    }
+    
+    public let bound: LocationBound
+    public var places: [Place]
+    public var count: Int {
+        return places.count
+    }
+    
+    public init(
+        bound: LocationBound,
+        places: [Place] = []
+    ) {
+        self.bound = bound
+        self.places = places
+    }
+    
+    public func isValidRange(_ place: Place) -> Bool {
+        return bound ~= place
+    }
+    
+}
+
+extension Cluster: Equatable {
+    
+    public static func == (lhs: Cluster, rhs: Cluster) -> Bool {
+        return lhs.center == rhs.center && lhs.count == rhs.count
+    }
+    
+}

--- a/client/Targets/Domain/Entities/Sources/Location/LocationBound.swift
+++ b/client/Targets/Domain/Entities/Sources/Location/LocationBound.swift
@@ -1,0 +1,30 @@
+//
+//  LocationBound.swift
+//  DomainEntities
+//
+//  Created by 홍성준 on 12/6/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+
+public struct LocationBound {
+    
+    public let southWest: LocationCoordinate
+    public let northEast: LocationCoordinate
+    
+    public init(southWest: LocationCoordinate, northEast: LocationCoordinate) {
+        self.southWest = southWest
+        self.northEast = northEast
+    }
+    
+}
+
+extension LocationBound {
+    
+    public static func ~= (bound: LocationBound, place: Place) -> Bool {
+        return (bound.southWest.lat...bound.northEast.lat) ~= place.lat &&
+        (bound.southWest.lng...bound.northEast.lng) ~= place.lng
+    }
+    
+}

--- a/client/Targets/Domain/Entities/Sources/Location/LocationCoordinate.swift
+++ b/client/Targets/Domain/Entities/Sources/Location/LocationCoordinate.swift
@@ -17,3 +17,17 @@ public struct LocationCoordinate {
         self.lng = lng
     }
 }
+
+extension LocationCoordinate: Hashable {
+    
+    public static let zero = LocationCoordinate(lat: 0, lng: 0)
+    
+    public static func + (lhs: LocationCoordinate, rhs: LocationCoordinate) -> LocationCoordinate {
+        return .init(lat: lhs.lat + rhs.lat, lng: lhs.lng + rhs.lng)
+    }
+    
+    public static func / (location: LocationCoordinate, div: Double) -> LocationCoordinate {
+        return .init(lat: location.lat / div, lng: location.lng / div)
+    }
+    
+}

--- a/client/Targets/Domain/Interfaces/Sources/Repository/ClusteringServiceInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/Repository/ClusteringServiceInterface.swift
@@ -1,0 +1,15 @@
+//
+//  ClusteringServiceInterface.swift
+//  DomainInterfaces
+//
+//  Created by 홍성준 on 12/6/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import DomainEntities
+
+public protocol ClusteringServiceInterface: AnyObject {
+    var clusteringCompletionBlock: (([Cluster]) -> Void)? { get set }
+    func clustering(bound: LocationBound, places: [Place])
+}

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchMap/SearchMapUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchMap/SearchMapUseCaseInterface.swift
@@ -7,9 +7,13 @@
 //
 
 import Foundation
+import Combine
 import DomainEntities
 
 public protocol SearchMapUseCaseInterface {
     var location: LocationCoordinate? { get }
+    var recommendPlaces: AnyPublisher<[Cluster], Never> { get }
     func fetchRecommendPlace(lat: Double, lng: Double) async -> Result<[Place], Error>
+    func fetchRecommendPlace(lat: Double, lng: Double)
+    func boundaryUpdated(zoomLevel: Double, boundary: LocationBound)
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapClusterMarkerAdpater.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapClusterMarkerAdpater.swift
@@ -1,0 +1,39 @@
+//
+//  SearchMapClusterMarkerAdpater.swift
+//  SearchImplementations
+//
+//  Created by 홍성준 on 12/6/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import NMapsMap
+import DomainEntities
+
+protocol SearchMapClusterMarkerAdpaterDelegate: AnyObject {
+    func searchMapMarkerDidTap(cluster: Cluster)
+}
+
+final class SearchMapClusterMarkerAdpater: MarkerAdaptable {
+    
+    weak var delegate: SearchMapClusterMarkerAdpaterDelegate?
+    
+    let marker: NMFMarker
+    let cluster: Cluster
+    
+    init(marker: NMFMarker, cluster: Cluster) {
+        self.marker = marker
+        self.cluster = cluster
+        
+        marker.touchHandler = { [weak self] overlay in
+            guard let self else { return false }
+            delegate?.searchMapMarkerDidTap(cluster: cluster)
+            return true
+        }
+    }
+    
+    func clear() {
+        marker.mapView = nil
+    }
+    
+}

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapMarkerAdapter.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapMarkerAdapter.swift
@@ -10,11 +10,15 @@ import Foundation
 import NMapsMap
 import DomainEntities
 
+protocol MarkerAdaptable: AnyObject {
+    func clear()
+}
+
 protocol SearchMapMarkerAdapterDelegate: AnyObject {
     func searchMapMarkerDidTap(place: Place)
 }
 
-final class SearchMapMarkerAdapter {
+final class SearchMapMarkerAdapter: MarkerAdaptable {
     
     weak var delegate: SearchMapMarkerAdapterDelegate?
     


### PR DESCRIPTION
## 🌁 배경
* #435 
* 클러스터링 로직만 추가했습니다. 아직 UI는 미완성입니다! 로직이 중요할 것 같아서 빠르게 PR드립니다.
* 전에 구두로 얘기했던 클러스터링 방식을 사용했습니다. 아래 리뷰 노트에 상세하게 적어두겠습니다. 
* 현재 O(n*m) 걸립니다 (n=스토리 개수, m=클러스터 개수)

## ✅ 수정 내역
* 지도 클러스터링 추가

## ⚙️ 테스트 방법
* 네이버 1784 위치에 스토리 찍어놔서 그 위치에서 줌인/줌아웃을 하면 됩니다.

## 📕 리뷰 노트
### 지도 클러스터링 로직
* 현재 지도 화면의 전체 크기를 가져옵니다 (Bound)
* 그 크기를 통해서 가로/세로 길이를 구합니다 (최대값 위경도 - 최소값 위경도)
* 구한 값을 정해진 수로 나눕니다 (sliceLat, sliceLng - ClusteringService에 값이 있음)
  * 이 값은 전체 화면의 가로/세로를 몇등분을 할 지에 대한 값입니다.
  * 이렇게 나눈 값을 클러스터이라 부르겠습니다.
* 해당 클러스터에 포함되는 스토리들을 클러스터에 추가합니다.

### 기타 로직
* 지도의 줌 레벨이 변경되면 클러스터링을 시도합니다.
* 기존에 있었던 클러스터들과 변경된 클러스터들이 동일한지 확인합니다.
  * 동일 - ViewController에게 알리지 않습니다.
  * 다름 - ViewController에게 알려 화면을 업데이트 합니다.
* 클러스터들이 동일한지 여부는 클러스터의 중앙 위치와 가지고 있는 스토리들의 개수입니다.

### 의사결정
* Operation Queue 사용
  * async/await 이나 Task로 묶을까 했는데 실제 동작이 async/await 하지 않아서 해당 키워드만으로 스레드 점유권을 양도하지 않았습니다.
  * 기존의 클러스터링 동작을 취소할 수 있어야 해서 OperationQueue를 활용했습니다.

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/3b7b47f8-8a2d-4a75-a251-f4db55d43c43


https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/de019c88-74a3-4713-877f-3e445d79d741



