### PR TITLE
fcm 토큰을 저장하는 api 생성

### DIFF
--- a/server/src/exception/custom.exception/fcm-token-save-failed.exception.ts
+++ b/server/src/exception/custom.exception/fcm-token-save-failed.exception.ts
@@ -1,0 +1,7 @@
+import { HttpException } from '@nestjs/common';
+
+export class FcmTokenSaveFailedException extends HttpException {
+  constructor() {
+    super('FCM Token 저장에 실패했습니다.', 503);
+  }
+}

--- a/server/src/notification/dto/save-token-request.dto.ts
+++ b/server/src/notification/dto/save-token-request.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SaveTokenRequestDto {
+  @ApiProperty({ example: 'my Story', description: 'FCM 토큰' })
+  @IsNotEmpty({ message: 'FCM 토큰 필수입니다.' })
+  @IsString()
+  fcmToken: string;
+}

--- a/server/src/notification/notification.controller.ts
+++ b/server/src/notification/notification.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { NotificationService } from './notification.service';
+import { SaveTokenRequestDto } from './dto/save-token-request.dto';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+
+@UseGuards(JwtAuthGuard)
+@ApiTags('notification')
+@Controller('notification')
+export class NotificationController {
+  constructor(private notificationService: NotificationService) {}
+
+  @Post('save-fcm-token')
+  @ApiOperation({ summary: 'fcm 토큰을 저장' })
+  @ApiResponse({
+    status: 201,
+    description: 'fcm 토큰을 저장합니다.',
+  })
+  async saveFcmToken(@Req() req: any, @Body() saveTokenRequestDto: SaveTokenRequestDto) {
+    const { fcmToken } = saveTokenRequestDto;
+    const message = await this.notificationService.saveFcmToken(req.user.userRecordId, fcmToken);
+    return { message: message };
+  }
+}

--- a/server/src/notification/notification.module.ts
+++ b/server/src/notification/notification.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { NotificationController } from './notification.controller';
+import { NotificationService } from './notification.service';
+
+@Module({
+  imports: [],
+  controllers: [NotificationController],
+  providers: [NotificationService],
+  exports: [],
+})
+export class NotificationModule {}

--- a/server/src/notification/notification.service.ts
+++ b/server/src/notification/notification.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { FcmTokenSaveFailedException } from '../exception/custom.exception/fcm-token-save-failed.exception';
+
+@Injectable()
+export class NotificationService {
+  public async saveFcmToken(userId: number, fcmToken: string) {
+    const api_url = 'http://175.45.201.252:3000/save-token';
+    try {
+      const response = await fetch(api_url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          userId: userId,
+          token: fcmToken,
+        }),
+      });
+
+      return response.text();
+    } catch (error) {
+      throw new FcmTokenSaveFailedException();
+    }
+  }
+}


### PR DESCRIPTION
## 🌁 배경
* #562 

## ✅ 수정 내역
* fcm 토큰을 저장하는 api 생성
* POST /notification/save-fcm-token
* Body 요구사항 => { fcmToken: string }

