### PR TITLE
지도 검색 라우팅 추가

### DIFF
--- a/client/Targets/Core/CoreKit/Sources/CoreUtil/String+.swift
+++ b/client/Targets/Core/CoreKit/Sources/CoreUtil/String+.swift
@@ -15,4 +15,17 @@ public extension String {
         return formatted
     }
     
+    var withoutHtml: String {
+        guard let data = self.data(using: .utf8) else {
+            return self
+        }
+        
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+        
+        return (try? NSAttributedString(data: data, options: options, documentAttributes: nil).string) ?? self
+    }
+    
 }

--- a/client/Targets/Data/Network/Search/Sources/DTO/NaverSearchLocalRequestDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/NaverSearchLocalRequestDTO.swift
@@ -32,8 +32,23 @@ public struct NaverSearchLocalDTO: Decodable {
 
 public extension NaverSearchLocalDTO {
     
-    func toDomain() -> SearchLocal {
-        .init(title: title, roadAddress: roadAddress)
+    func toDomain() -> SearchLocal? {
+        guard mapx.count >= 7, mapy.count >= 7 else { return nil }
+        let lng: Double? = {
+            let x = mapx.map { String($0) }
+            let ax = x[0..<x.count - 7].joined() + "." + x[x.count - 7..<x.count].joined()
+            return Double(ax)
+        }()
+        
+        let lat: Double? = {
+            let y = mapy.map { String($0) }
+            let ay = y[0..<y.count - 7].joined() + "." + y[y.count - 7..<y.count].joined()
+            return Double(ay)
+        }()
+        
+        guard let lat, let lng else { return nil}
+        
+        return .init(title: title, roadAddress: roadAddress, lat: lat, lng: lng)
     }
     
 }

--- a/client/Targets/Data/Network/Search/Sources/DTO/NaverSearchLocalRequestDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/NaverSearchLocalRequestDTO.swift
@@ -48,7 +48,12 @@ public extension NaverSearchLocalDTO {
         
         guard let lat, let lng else { return nil}
         
-        return .init(title: title, roadAddress: roadAddress, lat: lat, lng: lng)
+        return .init(
+            title: title.withoutHtml,
+            roadAddress: roadAddress.withoutHtml,
+            lat: lat,
+            lng: lng
+        )
     }
     
 }

--- a/client/Targets/Data/Network/Search/Sources/DTO/NaverSearchLocalResponseDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/NaverSearchLocalResponseDTO.swift
@@ -21,7 +21,7 @@ public struct NaverSearchLocalResponseDTO: Decodable {
 public extension NaverSearchLocalResponseDTO {
     
     func toDomain() -> [SearchLocal] {
-        items.map { .init(title: $0.title, roadAddress: $0.roadAddress) }
+        return items.compactMap { $0.toDomain() }
     }
     
 }

--- a/client/Targets/Domain/Entities/Sources/Search/SearchLocal.swift
+++ b/client/Targets/Domain/Entities/Sources/Search/SearchLocal.swift
@@ -12,10 +12,14 @@ public struct SearchLocal {
     
     public let title: String
     public let roadAddress: String
+    public let lat: Double
+    public let lng: Double
     
-    public init(title: String, roadAddress: String) {
+    public init(title: String, roadAddress: String, lat: Double, lng: Double) {
         self.title = title
         self.roadAddress = roadAddress
+        self.lat = lat
+        self.lng = lng
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -37,6 +37,7 @@ protocol SearchPresentable: Presentable {
     func showStoryView(model: SearchMapStoryViewModel)
     func showClusterListView(models: [SearchMapClusterListCellModel])
     func moveMap(lat: Double, lng: Double)
+    func selectMap(title: String, lat: Double, lng: Double)
     func updateMarkers(places: [Place])
     func updateMarkers(clusters: [Cluster])
     func removeAllMarker()
@@ -118,6 +119,11 @@ final class SearchInteractor: PresentableInteractor<SearchPresentable>,
     func searchCurrentLocationStoryListDidTapStory(_ storyId: Int) {
         router?.detachSearchCurrentLocation()
         router?.attachStoryDetail(storyId: storyId)
+    }
+    
+    func searchResultDidTapLocal(_ local: SearchLocal) {
+        router?.detachSearchResult()
+        presenter.selectMap(title: local.title, lat: local.lat, lng: local.lng)
     }
     
     private func bind() {
@@ -301,7 +307,6 @@ private extension SearchInteractor {
         let distance = abs(fetchedLocation.lat - location.lat) + abs(fetchedLocation.lng - location.lng)
         return distance >= 0.02
     }
-    
     
 }
 

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -124,6 +124,7 @@ final class SearchInteractor: PresentableInteractor<SearchPresentable>,
     func searchResultDidTapLocal(_ local: SearchLocal) {
         router?.detachSearchResult()
         presenter.selectMap(title: local.title, lat: local.lat, lng: local.lng)
+        didTapReSearch()
     }
     
     private func bind() {

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -167,8 +167,7 @@ extension SearchInteractor: SearchPresentableListener {
     
     func didAppear() {
         if !isInitialCameraMoved {
-            // TODO: - Default Location 설정하기
-            let location = dependency.searchUseCase.location ?? .init(lat: 37, lng: 127)
+            let location = dependency.searchUseCase.location ?? .init(lat: 37.3588501438082, lng: 127.1052074432373)
             isInitialCameraMoved = true
             presenter.moveMap(lat: location.lat, lng: location.lng)
             fetchPlaces(lat: location.lat, lng: location.lng)

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -41,7 +41,7 @@ protocol SearchPresentable: Presentable {
     func updateMarkers(places: [Place])
     func updateMarkers(clusters: [Cluster])
     func removeAllMarker()
-    func updateSelectedMarker(title: String, lat: Double, lng: Double)
+    func updateSelectedMarker(lat: Double, lng: Double)
     func showSelectedView(title: String)
     func showReSearchView()
     func hideReSearchView()
@@ -190,7 +190,6 @@ extension SearchInteractor: SearchPresentableListener {
     func didTapSymbol(symbol: SearchMapSymbol) {
         presenter.deselectAll()
         presenter.updateSelectedMarker(
-            title: symbol.title,
             lat: symbol.lat,
             lng: symbol.lng
         )
@@ -202,7 +201,6 @@ extension SearchInteractor: SearchPresentableListener {
         let title = "위치 정보가 없어요"
         presenter.deselectAll()
         presenter.updateSelectedMarker(
-            title: "",
             lat: location.lat,
             lng: location.lng
         )
@@ -261,7 +259,6 @@ extension SearchInteractor: SearchPresentableListener {
             ))
             
             presenter.updateSelectedMarker(
-                title: place.title,
                 lat: place.lat,
                 lng: place.lng
             )
@@ -276,7 +273,6 @@ extension SearchInteractor: SearchPresentableListener {
             )}
             presenter.showClusterListView(models: models)
             presenter.updateSelectedMarker(
-                title: "",
                 lat: cluster.center.lat,
                 lng: cluster.center.lng
             )

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterDashboardInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterDashboardInteractor.swift
@@ -37,6 +37,8 @@ protocol SearchAfterDashboardListener: AnyObject {
     
     func searchUserSeeAllDidTap(searchText: String)
     func didTapUser(userId: Int)
+    
+    func searchAfterDashboardDidTapLocal(_ local: SearchLocal)
 }
 
 final class SearchAfterDashboardInteractor: PresentableInteractor<SearchAfterDashboardPresentable>, SearchAfterDashboardInteractable, SearchAfterDashboardPresentableListener {
@@ -110,6 +112,10 @@ final class SearchAfterDashboardInteractor: PresentableInteractor<SearchAfterDas
         router?.detachSearchAfterLocalDasboard()
         router?.detachSearchAfterStoryDashboard()
         router?.detachSearchAfterUserDashboard()
+    }
+    
+    func searchAfterLocalDashboardDidTapLocal(_ local: SearchLocal) {
+        listener?.searchAfterDashboardDidTapLocal(local)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterLocalDashboard/SearchAfterLocalDashboardInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterLocalDashboard/SearchAfterLocalDashboardInteractor.swift
@@ -15,7 +15,7 @@ import CoreKit
 import DomainEntities
 import DomainInterfaces
 
-protocol SearchAfterLocalDashboardRouting: ViewableRouting { }
+protocol SearchAfterLocalDashboardRouting: ViewableRouting {}
 
 protocol SearchAfterLocalDashboardPresentable: Presentable {
     var listener: SearchAfterLocalDashboardPresentableListener? { get set }
@@ -24,6 +24,7 @@ protocol SearchAfterLocalDashboardPresentable: Presentable {
 
 protocol SearchAfterLocalDashboardListener: AnyObject {
     var searchResultLocalsPublisher: AnyPublisher<[SearchLocal], Never> { get }
+    func searchAfterLocalDashboardDidTapLocal(_ local: SearchLocal)
 }
 
 final class SearchAfterLocalDashboardInteractor: PresentableInteractor<SearchAfterLocalDashboardPresentable>, SearchAfterLocalDashboardInteractable, SearchAfterLocalDashboardPresentableListener {
@@ -46,9 +47,13 @@ final class SearchAfterLocalDashboardInteractor: PresentableInteractor<SearchAft
                 self?.presenter.setup(models: users)
             }.store(in: &cancellables)
     }
-
+    
     override func willResignActive() {
         super.willResignActive()
+    }
+    
+    func didTap(local: SearchLocal) {
+        listener?.searchAfterLocalDashboardDidTapLocal(local)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterLocalDashboard/SearchAfterLocalDashboardViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterLocalDashboard/SearchAfterLocalDashboardViewController.swift
@@ -14,7 +14,7 @@ import DesignKit
 import DomainEntities
 
 protocol SearchAfterLocalDashboardPresentableListener: AnyObject {
-    
+    func didTap(local: SearchLocal)
 }
 
 final class SearchAfterLocalDashboardViewController: UIViewController, SearchAfterLocalDashboardPresentable, SearchAfterLocalDashboardViewControllable {
@@ -119,6 +119,10 @@ extension SearchAfterLocalDashboardViewController: SearchAfterHeaderViewDelegate
 }
 
 extension SearchAfterLocalDashboardViewController: SearchAfterLocalViewDelegate {
+    
+    func searchAfterLocalViewDidTap(_ view: SearchAfterLocalView, model: SearchLocal) {
+        listener?.didTap(local: model)
+    }
     
 }
 

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterLocalDashboard/Views/SearchAfterLocalView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterLocalDashboard/Views/SearchAfterLocalView.swift
@@ -13,7 +13,7 @@ import DesignKit
 
 
 protocol SearchAfterLocalViewDelegate: AnyObject {
-    
+    func searchAfterLocalViewDidTap(_ view: SearchAfterLocalView, model: SearchLocal)
 }
 
 final class SearchAfterLocalView: UIView {
@@ -23,6 +23,8 @@ final class SearchAfterLocalView: UIView {
     private enum Constant {
         static let spacing: CGFloat = 5
     }
+    
+    private var model: SearchLocal?
     
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -59,6 +61,7 @@ final class SearchAfterLocalView: UIView {
     func setup(model: SearchLocal) {
         titleLabel.text = model.title
         roadAddressLabel.text = model.roadAddress
+        self.model = model
     }
        
 }
@@ -92,7 +95,8 @@ private extension SearchAfterLocalView {
 private extension SearchAfterLocalView {
     
     @objc func searchAfterLocalViewDidTap() {
-        
+        guard let model else { return }
+        delegate?.searchAfterLocalViewDidTap(self, model: model)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchResultInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchResultInteractor.swift
@@ -46,6 +46,8 @@ protocol SearchResultListener: AnyObject {
     
     func searchUserSeeAllDidTap(searchText: String)
     func didTapUser(userId: Int)
+    
+    func searchResultDidTapLocal(_ local: SearchLocal)
 }
 
 final class SearchResultInteractor: PresentableInteractor<SearchResultPresentable>, SearchResultInteractable {
@@ -161,6 +163,10 @@ extension SearchResultInteractor {
     
     func didTapUser(userId: Int) {
         listener?.didTapUser(userId: userId)
+    }
+    
+    func searchAfterDashboardDidTapLocal(_ local: SearchLocal) {
+        listener?.searchResultDidTapLocal(local)
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
@@ -119,9 +119,8 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
         markerStorage.removeAll()
     }
     
-    func updateSelectedMarker(title: String, lat: Double, lng: Double) {
+    func updateSelectedMarker(lat: Double, lng: Double) {
         selectedMarker.position = .init(lat: lat, lng: lng)
-        selectedMarker.captionText = title
         selectedMarker.mapView = naverMap.mapView
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
@@ -83,6 +83,15 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
         naverMap.mapView.moveCamera(cameraUpdate)
     }
     
+    func selectMap(title: String, lat: Double, lng: Double) {
+        moveMap(lat: lat, lng: lng)
+        listener?.didTapSymbol(symbol: .init(
+            title: title,
+            lat: lat,
+            lng: lng
+        ))
+    }
+    
     func updateMarkers(places: [Place]) {
         let overlay = NMFOverlayImage(image: .marker)
         

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
@@ -84,7 +84,8 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
     }
     
     func selectMap(title: String, lat: Double, lng: Double) {
-        moveMap(lat: lat, lng: lng)
+        let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(lat: lat, lng: lng), zoomTo: 15.0)
+        naverMap.mapView.moveCamera(cameraUpdate)
         listener?.didTapSymbol(symbol: .init(
             title: title,
             lat: lat,
@@ -228,6 +229,7 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
         
         selectedMarker.do {
             $0.iconImage = NMFOverlayImage(image: .markerBlue)
+            $0.zIndex = 1
         }
         
         selectedView.do {


### PR DESCRIPTION
## 🌁 배경
* close #536 
* 네이버 검색 API 탭 되었을 때 라우팅 동작 추가했습니다.
* 따로 네이버 검색 API에 가이드라인이 없어서 일단 받은 String 잘라서 사용하는 것으로 했습니다.
  * 가이드라인이 없어서 불안하긴 합니다 ㅋㅋ.. 일단 잘 동작해서 넣어두겠습니다.
* 위치 정보 없을 때 default 위치로 네이버 1784 로 찍어놨습니다.

## ✅ 수정 내역
* 네이버 검색 후 지도 라우팅 추가
* HTML 태그 제거

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/9b632d3e-5b6e-4241-a03d-3440158c7557

