### PR TITLE
검색 탭 버그 수정

### DIFF
--- a/client/Targets/Core/FoundationKit/Sources/UserDefaults/UserDefaults+.swift
+++ b/client/Targets/Core/FoundationKit/Sources/UserDefaults/UserDefaults+.swift
@@ -30,6 +30,10 @@ public extension UserDefaults {
         object(forKey: key.rawValue)
     }
     
+    func array(forKey key: UserDefaults.Key) -> [Any]? {
+        array(forKey: key.rawValue)
+    }
+    
     func removeObject(forKey key: UserDefaults.Key) {
         removeObject(forKey: key.rawValue)
     }

--- a/client/Targets/Core/FoundationKit/Sources/UserDefaults/UserDefaults+Key.swift
+++ b/client/Targets/Core/FoundationKit/Sources/UserDefaults/UserDefaults+Key.swift
@@ -14,6 +14,7 @@ public extension UserDefaults {
         
         case remoteNotification
         case initialSignInDate
+        case recentSearch
         
     }
     

--- a/client/Targets/Data/Network/Search/Sources/DTO/SearchRecommendResponseDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/SearchRecommendResponseDTO.swift
@@ -16,7 +16,7 @@ public struct SearchRecommendResponseDTO: Decodable {
 
 public extension SearchRecommendResponseDTO {
     
-    func toDmain() -> [String] {
+    func toDomain() -> [String] {
         recommends
     }
     

--- a/client/Targets/Data/Network/Search/Sources/DTO/SearchRequestDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/SearchRequestDTO.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct SearchRequestDTO: Encodable {
 
     let searchText: String
-    let offset: Int = 0
-    let limit: Int = 25
+    let offset: Int
+    let limit: Int
     
 }

--- a/client/Targets/Data/Network/Search/Sources/DTO/SearchStroyDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/SearchStroyDTO.swift
@@ -22,7 +22,6 @@ public struct SearchStroyDTO: Decodable {
     
 }
 
-
 public extension SearchStroyDTO {
     
     func toDomain() -> SearchStory {

--- a/client/Targets/Data/Network/Search/Sources/DTO/SearchStroyResponseDTO.swift
+++ b/client/Targets/Data/Network/Search/Sources/DTO/SearchStroyResponseDTO.swift
@@ -11,7 +11,7 @@ import DomainEntities
 
 public struct SearchStroyResponseDTO: Decodable {
     
-    public let stories: [SearchStroyDTO]
+    public let stories: [SearchStroyDTO?]
     public let isLastPage: Bool
     
 }
@@ -19,7 +19,7 @@ public struct SearchStroyResponseDTO: Decodable {
 public extension SearchStroyResponseDTO {
     
     func toDomain() -> [SearchStory] {
-        stories.map { $0.toDomain() }
+        stories.compactMap { $0?.toDomain() }
     }
 
 }

--- a/client/Targets/Data/Network/Search/Sources/SearchAPI.swift
+++ b/client/Targets/Data/Network/Search/Sources/SearchAPI.swift
@@ -13,8 +13,8 @@ import DomainEntities
 
 public enum SearchAPI {
     case searchResult(search: SearchRequest)
-    case story(searchText: String)
-    case user(searchText: String)
+    case story(searchText: String, offset: Int, limit: Int)
+    case user(searchText: String, offset: Int, limit: Int)
     case recommend(searchText: String)
     case category
 }
@@ -45,15 +45,19 @@ extension SearchAPI: Target {
     public var task: Task {
         switch self {
         case let .searchResult(search):
-            .url(parameters: SearchResultRequestDTO(search).parameters())
-        case let .story(searchText):
-            makeSearchRequestDTO(searchText: searchText)
-        case let .user(searchText):
-            makeSearchRequestDTO(searchText: searchText)
+            return .url(parameters: SearchResultRequestDTO(search).parameters())
+            
+        case let .story(searchText, offset, limit):
+            return makeSearchRequestDTO(searchText: searchText, offset: offset, limit: limit)
+            
+        case let .user(searchText, offset, limit):
+            return makeSearchRequestDTO(searchText: searchText, offset: offset, limit: limit)
+            
         case let .recommend(searchText):
-            makeSearchRequestDTO(searchText: searchText)
+            return .url(parameters: ["searchText": searchText])
+            
         case .category:
-            .plain
+            return .plain
         }
     }
     
@@ -61,8 +65,8 @@ extension SearchAPI: Target {
 
 private extension SearchAPI {
     
-    func makeSearchRequestDTO(searchText: String) -> Task {
-        let request = SearchRequestDTO(searchText: searchText)
+    func makeSearchRequestDTO(searchText: String, offset: Int, limit: Int) -> Task {
+        let request = SearchRequestDTO(searchText: searchText, offset: offset, limit: limit)
         return .url(parameters: request.parameters())
     }
     

--- a/client/Targets/Data/Network/Search/Sources/URLProtocols/SearchURLProtocol.swift
+++ b/client/Targets/Data/Network/Search/Sources/URLProtocols/SearchURLProtocol.swift
@@ -13,8 +13,8 @@ public final class SearchURLProtocol: URLProtocol {
     
     private lazy var mocks: [String: Data?] = [
         SearchAPI.recommend(searchText: "text").path: loadMockData(fileName: "SearchRecommendResponseMock"),
-        SearchAPI.story(searchText: "text").path: loadMockData(fileName: "SearchStoryResponseMock"),
-        SearchAPI.user(searchText: "text").path: loadMockData(fileName: "SearchUserResponseMock")
+        SearchAPI.story(searchText: "text", offset: 0, limit: 5).path: loadMockData(fileName: "SearchStoryResponseMock"),
+        SearchAPI.user(searchText: "text", offset: 0, limit: 5).path: loadMockData(fileName: "SearchUserResponseMock")
     ]
     
     public override class func canInit(with request: URLRequest) -> Bool { true }

--- a/client/Targets/Domain/Interfaces/Sources/Repository/Search/SearchSeeAllRepositoryInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/Repository/Search/SearchSeeAllRepositoryInterface.swift
@@ -11,7 +11,7 @@ import DomainEntities
 
 public protocol SearchSeeAllRepositoryInterface {
     
-    func fetchStory(searchText: String) async -> Result<[SearchStory], Error>
-    func fetchUser(searchText: String) async -> Result<[SearchUser], Error>
+    func fetchStory(searchText: String, offset: Int, limit: Int) async -> Result<[SearchStory], Error>
+    func fetchUser(searchText: String, offset: Int, limit: Int) async -> Result<[SearchUser], Error>
     
 }

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchSeeAll/SearchStorySeeAllUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchSeeAll/SearchStorySeeAllUseCaseInterface.swift
@@ -13,6 +13,8 @@ import DomainEntities
 
 public protocol SearchStorySeeAllUseCaseInterface {
     
+    var hasMoreStory: Bool { get }
     func fetchStory(searchText: String) async -> Result<[SearchStory], Error>
+    func loadMoreStory(searchText: String) async -> Result<[SearchStory], Error> 
     
 }

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchSeeAll/SearchUserSeeAllUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchSeeAll/SearchUserSeeAllUseCaseInterface.swift
@@ -11,6 +11,8 @@ import DomainEntities
 
 public protocol SearchUserSeeAllUseCaseInterface {
     
+    var hasMoreUser: Bool { get }
     func fetchUser(searchText: String) async -> Result<[SearchUser], Error>
+    func loadMoreUser(searchText: String) async -> Result<[SearchUser], Error>
     
 }

--- a/client/Targets/Domain/UseCases/Sources/SearchUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/SearchUseCase.swift
@@ -23,12 +23,26 @@ public final class SearchUseCase: SearchUseCaseInterface {
         return recommendPlaceClusterSubject.eraseToAnyPublisher()
     }
     
+    public var hasMoreStory: Bool {
+        return !isStoryLastPage
+    }
+    
+    public var hasMoreUser: Bool {
+        return !isUserLastPage
+    }
+    
     private let repository: SearchRepositoryInterface
     private let locationService: LocationServiceInterface
     private let clusteringService: ClusteringServiceInterface
     
     private let recommendPlacesCurrentValue = CurrentValueSubject<[Place], Never>([])
     private let recommendPlaceClusterSubject = CurrentValueSubject<[Cluster], Never>([])
+    
+    private var searchStoryOffset = 0
+    private var searchUserOffset = 0
+    private let pageLimit = 10
+    private var isStoryLastPage = true
+    private var isUserLastPage = true
     
     private var boundary: LocationBound?
     private var zoomLevel: Double?
@@ -57,11 +71,23 @@ public final class SearchUseCase: SearchUseCaseInterface {
     }
     
     public func fetchStory(searchText: String) async -> Result<[SearchStory], Error> {
-        await repository.fetchStory(searchText: searchText)
+        searchStoryOffset = 0
+        return await fetchStoryWithPaging(text: searchText, offset: searchStoryOffset, limit: pageLimit)
+    }
+    
+    public func loadMoreStory(searchText: String) async -> Result<[SearchStory], Error> {
+        searchStoryOffset += 1
+        return await fetchStoryWithPaging(text: searchText, offset: searchStoryOffset, limit: pageLimit)
     }
     
     public func fetchUser(searchText: String) async -> Result<[SearchUser], Error> {
-        await repository.fetchUser(searchText: searchText)
+        searchUserOffset = 0
+        return await fetchUserWithPaging(text: searchText, offset: searchUserOffset, limit: pageLimit)
+    }
+    
+    public func loadMoreUser(searchText: String) async -> Result<[SearchUser], Error> {
+        searchUserOffset += 1
+        return await fetchUserWithPaging(text: searchText, offset: searchUserOffset, limit: pageLimit)
     }
     
     public func fetchRecommendTexts(searchText: String) async -> Result<[String], Error> {
@@ -150,6 +176,30 @@ public final class SearchUseCase: SearchUseCaseInterface {
                 recommendPlaceClusterSubject.send(clusters)
             }
         }
+    }
+    
+    private func fetchStoryWithPaging(text: String, offset: Int, limit: Int) async -> Result<[SearchStory], Error> {
+        let result = await repository.fetchStory(searchText: text, offset: offset, limit: limit)
+        switch result {
+        case .success(let stories):
+            isStoryLastPage = stories.count != limit
+            
+        case .failure:
+            isStoryLastPage = true
+        }
+        return result
+    }
+    
+    private func fetchUserWithPaging(text: String, offset: Int, limit: Int) async -> Result<[SearchUser], Error> {
+        let result = await repository.fetchUser(searchText: text, offset: offset, limit: limit)
+        switch result {
+        case .success(let users):
+            isUserLastPage = users.count != limit
+            
+        case .failure:
+            isUserLastPage = true
+        }
+        return result
     }
     
 }

--- a/client/Targets/Presentation/BasePresentation/Sources/Story/StorySeeAll/StorySeeAllViewController.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/Story/StorySeeAll/StorySeeAllViewController.swift
@@ -74,7 +74,7 @@ public final class StorySeeAllViewController: BaseViewController, StorySeeAllPre
         }
         
         tableView.do {
-            $0.backgroundColor = .white
+            $0.backgroundColor = .hpWhite
             $0.register(StorySmallTableViewCell.self)
             $0.delegate = self
             $0.dataSource = self

--- a/client/Targets/Presentation/BasePresentation/Sources/User/Cells/UserSmallTableViewCell.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/User/Cells/UserSmallTableViewCell.swift
@@ -7,9 +7,7 @@
 //
 
 import UIKit
-
 import DesignKit
-
 
 public struct UserSmallTableViewCellModel {
     
@@ -28,8 +26,7 @@ public struct UserSmallTableViewCellModel {
 public final class UserSmallTableViewCell: UITableViewCell {
     
     private enum Constant {
-        static let leadingOffset: CGFloat = 10
-        static let trailingOffset: CGFloat = -leadingOffset
+        static let spacing: CGFloat = 10
         
         enum ProfileImageView {
             static let width: CGFloat = 40
@@ -50,28 +47,10 @@ public final class UserSmallTableViewCell: UITableViewCell {
     
     private let nicknameLabel: UILabel = {
         let label = UILabel()
-        label.font = .captionBold
+        label.font = .bodySemibold
         label.textColor = .hpBlack
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
-    }()
-    
-    private let badgeLabel: UILabel = {
-        let label = UILabel()
-        label.font = .smallRegular
-        label.textColor = .hpGray1
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private lazy var stackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.spacing = 3
-        stackView.alignment = .center
-        stackView.distribution = .equalSpacing
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
     }()
     
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -92,7 +71,6 @@ public final class UserSmallTableViewCell: UITableViewCell {
     public func setup(model: UserSmallTableViewCellModel) {
         profileImageView.load(from: model.profileUrl)
         nicknameLabel.text = model.username
-        badgeLabel.text = model.username
     }
     
 }
@@ -102,19 +80,18 @@ private extension UserSmallTableViewCell {
     func setupViews() {
         selectionStyle = .none
         backgroundColor = .hpWhite
-        [nicknameLabel, badgeLabel].forEach(stackView.addArrangedSubview)
-        [profileImageView, stackView].forEach(contentView.addSubview)
+        [profileImageView, nicknameLabel].forEach(contentView.addSubview)
         
         NSLayoutConstraint.activate([
             profileImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            profileImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            profileImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.leadingOffset),
             profileImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             profileImageView.heightAnchor.constraint(equalToConstant: Constant.ProfileImageView.height),
             profileImageView.widthAnchor.constraint(equalToConstant: Constant.ProfileImageView.width),
             
-            stackView.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: Constant.leadingOffset),
-            stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            stackView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: Constant.trailingOffset)
+            nicknameLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: Constant.spacing),
+            nicknameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            nicknameLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: Constants.traillingOffset)
         ])
     }
     
@@ -122,7 +99,6 @@ private extension UserSmallTableViewCell {
         profileImageView.cancel()
         profileImageView.image = nil
         nicknameLabel.text = nil
-        badgeLabel.text = nil
     }
     
 }

--- a/client/Targets/Presentation/BasePresentation/Sources/User/UserSeeAll/UserSeeAllPresentable.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/User/UserSeeAll/UserSeeAllPresentable.swift
@@ -14,4 +14,6 @@ public protocol UserSeeAllPresentable: Presentable {
     func updateTitle(_ title: String)
     func setup(models: [UserSmallTableViewCellModel])
     func append(models: [UserSmallTableViewCellModel])
+    func startLoading()
+    func stopLoading()
 }

--- a/client/Targets/Presentation/BasePresentation/Sources/User/UserSeeAll/UserSeeAllViewController.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/User/UserSeeAll/UserSeeAllViewController.swift
@@ -90,10 +90,6 @@ public final class UserSeeAllViewController: BaseViewController, UserSeeAllPrese
         }
     }
     
-    public override func bind() {
-       
-    }
-    
 }
 
 extension UserSeeAllViewController: NavigationViewDelegate {

--- a/client/Targets/Presentation/BasePresentation/Sources/User/UserSeeAll/UserSeeAllViewController.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/User/UserSeeAll/UserSeeAllViewController.swift
@@ -13,6 +13,7 @@ import DesignKit
 public protocol UserSeeAllPresentableListener: AnyObject {
     func didTapItem(model: UserSmallTableViewCellModel)
     func didTapClose()
+    func willDisplay(at indexPath: IndexPath)
 }
 
 public final class UserSeeAllViewController: BaseViewController, UserSeeAllPresentable, UserSeeAllViewControllable {
@@ -21,7 +22,8 @@ public final class UserSeeAllViewController: BaseViewController, UserSeeAllPrese
     
     private var models: [UserSmallTableViewCellModel] = []
     
-    private let tableView = UITableView()
+    private let tableView = UITableView(frame: .zero, style: .grouped)
+    private let indicator = UIActivityIndicatorView(style: .medium)
     
     public func updateTitle(_ title: String) {
         navigationView.updateTitle(title)
@@ -35,6 +37,14 @@ public final class UserSeeAllViewController: BaseViewController, UserSeeAllPrese
     public func append(models: [UserSmallTableViewCellModel]) {
         self.models.append(contentsOf: models)
         tableView.reloadData()
+    }
+    
+    public func startLoading() {
+        indicator.startAnimating()
+    }
+    
+    public func stopLoading() {
+        indicator.stopAnimating()
     }
     
     public override func setupLayout() {
@@ -63,10 +73,20 @@ public final class UserSeeAllViewController: BaseViewController, UserSeeAllPrese
         }
         
         tableView.do {
+            $0.backgroundColor = .hpWhite
             $0.register(UserSmallTableViewCell.self)
             $0.delegate = self
             $0.dataSource = self
+            $0.contentInset = .zero
+            $0.separatorStyle = .none
+            $0.tableFooterView = indicator
             $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        indicator.do {
+            $0.color = .hpGray2
+            $0.hidesWhenStopped = true
+            $0.stopAnimating()
         }
     }
     
@@ -91,12 +111,16 @@ extension UserSeeAllViewController: UITableViewDelegate {
         listener?.didTapItem(model: model)
     }
     
+    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        listener?.willDisplay(at: indexPath)
+    }
+    
 }
 
 extension UserSeeAllViewController: UITableViewDataSource {
     
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        models.count
+        return models.count
     }
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -301,7 +301,7 @@ private extension SearchInteractor {
     func isReSearchEnabled(location: SearchMapLocation) -> Bool {
         guard let fetchedLocation else { return false }
         let distance = abs(fetchedLocation.lat - location.lat) + abs(fetchedLocation.lng - location.lng)
-        return distance >= 0.02
+        return distance >= 0.005
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterDashboardViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterDashboardViewController.swift
@@ -67,16 +67,16 @@ private extension SearchAfterDashboardViewController {
         scrollView.addSubview(stackView)
         
         NSLayoutConstraint.activate([
-            scrollView.frameLayoutGuide.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constant.spacing),
-            scrollView.frameLayoutGuide.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.frameLayoutGuide.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.frameLayoutGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constant.spacing),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             
-            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
-            stackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
         ])
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterLocalDashboard/SearchAfterLocalDashboardViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterLocalDashboard/SearchAfterLocalDashboardViewController.swift
@@ -75,7 +75,7 @@ final class SearchAfterLocalDashboardViewController: UIViewController, SearchAft
     func setup(models: [SearchLocal]) {
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         let isEmpty = models.isEmpty
-        headerView.isHiddenSeeAllView(isEmpty)
+        headerView.isHiddenSeeAllView(true) // 일단 모두 보기 보여주지 않음
         models.forEach { model in
             let contentView = SearchAfterLocalView()
             contentView.setup(model: model)

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterUserDashboard/SearchAfterUserDashboardViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterUserDashboard/SearchAfterUserDashboardViewController.swift
@@ -80,7 +80,7 @@ final class SearchAfterUserDashboardViewController: UIViewController, SearchAfte
             let contentView = SearchAfterUserView()
             contentView.setup(model: model)
             contentView.delegate = self
-            self.stackView.addArrangedSubview(contentView)
+            stackView.addArrangedSubview(contentView)
         }
         emptyView.isHidden = !isEmpty
     }
@@ -92,19 +92,18 @@ private extension SearchAfterUserDashboardViewController {
         [headerView, emptyView, stackView].forEach { view.addSubview($0) }
         
         NSLayoutConstraint.activate([
-            headerView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            headerView.topAnchor.constraint(equalTo: view.topAnchor),
             headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
             headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
             
             emptyView.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: Constant.offset),
             emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
             emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
-            emptyView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             
             stackView.topAnchor.constraint(equalTo: headerView.bottomAnchor, constant: Constant.offset),
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
-            stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterUserDashboard/Views/SearchAfterUserView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterUserDashboard/Views/SearchAfterUserView.swift
@@ -36,33 +36,24 @@ final class SearchAfterUserView: UIView {
         imageView.clipsToBounds = true
         imageView.layer.cornerRadius = Constant.ProfileImageView.height / 2
         imageView.contentMode = .scaleAspectFill
-        imageView.backgroundColor = .hpGray3
+        imageView.backgroundColor = .hpGray4
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
     
     private let nicknameLabel: UILabel = {
         let label = UILabel()
-        label.font = .captionBold
+        label.font = .bodySemibold
         label.textColor = .hpBlack
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private let badgeLabel: UILabel = {
-        let label = UILabel()
-        label.font = .smallRegular
-        label.textColor = .hpGray1
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
     private lazy var stackView: UIStackView = {
-       let stackView = UIStackView(arrangedSubviews: [nicknameLabel, badgeLabel])
+        let stackView = UIStackView(arrangedSubviews: [nicknameLabel])
         stackView.axis = .vertical
         stackView.spacing = 3
-        stackView.alignment = .center
-        stackView.distribution = .equalSpacing
+        stackView.alignment = .fill
+        stackView.distribution = .fill
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -82,7 +73,6 @@ final class SearchAfterUserView: UIView {
     func setup(model: SearchUser) {
         profileImageView.load(from: model.profileUrl)
         nicknameLabel.text = model.username
-        badgeLabel.text = model.username
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterUserDashboard/Views/SearchAfterUserView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchAfterDashboard/SearchAfterUserDashboard/Views/SearchAfterUserView.swift
@@ -71,6 +71,7 @@ final class SearchAfterUserView: UIView {
     }
     
     func setup(model: SearchUser) {
+        userId = model.userId
         profileImageView.load(from: model.profileUrl)
         nicknameLabel.text = model.username
     }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchResultViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/SearchResultViewController.swift
@@ -76,6 +76,10 @@ final class SearchResultViewController: BaseViewController, SearchResultViewCont
     override func setupAttributes() {
         view.backgroundColor = .hpWhite
         
+        navigationView.do {
+            $0.delegate = self
+        }
+        
         searchNavigationView.do {
             $0.delegate = self
             $0.translatesAutoresizingMaskIntoConstraints = false

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchRouter.swift
@@ -141,11 +141,9 @@ extension SearchRouter {
     }
     
     func detachUserDetail() {
-        Log.make(message: "\(String(describing: self)) \(#function) start", log: .default)
         guard let router = userProfileRouter else { return }
         popRouter(router, animated: true)
         userProfileRouter = nil
-        Log.make(message: "\(String(describing: self)) \(#function) finish", log: .default)
     }
     
     func attachSearchUserSeeAll(searchText: String) {

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
@@ -55,7 +55,7 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
     private var markerStorage: [MarkerAdaptable] = []
     
     private lazy var naverMap = NMFNaverMapView(frame: view.frame)
-    private let searchTextField = SearchTextField()
+    private let searchView = SearchMapSearchView()
     private let showSearchHomeListButton = UIButton(configuration: .filled())
     private let storyView = SearchMapStoryView()
     private let selectedMarker = NMFMarker()
@@ -162,15 +162,14 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
     override func setupLayout() {
         view = naverMap
         
-        [searchTextField, reSearchView, showSearchHomeListButton, storyView, selectedView, selectedClusterView].forEach(view.addSubview)
+        [searchView, reSearchView, showSearchHomeListButton, storyView, selectedView, selectedClusterView].forEach(view.addSubview)
         
         NSLayoutConstraint.activate([
-            searchTextField.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constant.SearchTextField.topSpacing),
-            searchTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
-            searchTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
-            searchTextField.heightAnchor.constraint(equalToConstant: Constants.navigationViewHeight),
+            searchView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constant.SearchTextField.topSpacing),
+            searchView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
+            searchView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
             
-            reSearchView.topAnchor.constraint(equalTo: searchTextField.bottomAnchor, constant: 10),
+            reSearchView.topAnchor.constraint(equalTo: searchView.bottomAnchor, constant: 10),
             reSearchView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             
             showSearchHomeListButton.widthAnchor.constraint(equalToConstant: Constant.ShowSearchHomeListButton.length),
@@ -202,8 +201,7 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
             $0.mapView.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        searchTextField.do {
-            $0.placeholder = Constant.SearchTextField.placeholder
+        searchView.do {
             $0.clipsToBounds = true
             $0.layer.cornerRadius = Constants.cornerRadiusMedium
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -250,7 +248,7 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
     }
     
     override func bind() {
-        searchTextField
+        searchView
             .tapGesturePublisher
             .withOnly(self)
             .sink { this in

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
@@ -198,6 +198,7 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
             $0.showLocationButton = true
             $0.mapView.addCameraDelegate(delegate: self)
             $0.mapView.touchDelegate = self
+            $0.showCompass = false
             $0.mapView.translatesAutoresizingMaskIntoConstraints = false
         }
         

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SeeAll/Story/SearchStorySeeAllInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SeeAll/Story/SearchStorySeeAllInteractor.swift
@@ -36,7 +36,7 @@ final class SearchStorySeeAllInteractor: PresentableInteractor<SearchStorySeeAll
     weak var listener: SearchStorySeeAllListener?
     
     private let dependency: SearchStorySeeAllInteractorDependency
-    private var cancelBag = CancelBag()
+    private let cancelBag = CancelBag()
     private var models: [StorySmallTableViewCellModel] = []
     private var isLoading = false
     
@@ -57,7 +57,6 @@ final class SearchStorySeeAllInteractor: PresentableInteractor<SearchStorySeeAll
     
     override func willResignActive() {
         super.willResignActive()
-        print("# 리자인됨?")
         cancelBag.cancel()
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SeeAll/User/SearchUserSeeAllInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SeeAll/User/SearchUserSeeAllInteractor.swift
@@ -7,13 +7,11 @@
 //
 
 import Foundation
-
 import ModernRIBs
-
 import CoreKit
 import BasePresentation
+import DomainEntities
 import DomainInterfaces
-
 
 protocol SearchUserSeeAllRouting: ViewableRouting { }
 
@@ -31,15 +29,20 @@ protocol SearchUserSeeAllInteractorDependency: AnyObject {
 }
 
 final class SearchUserSeeAllInteractor: PresentableInteractor<SearchUserSeeAllPresentable>,
-                                            SearchUserSeeAllInteractable,
+                                        SearchUserSeeAllInteractable,
                                         SearchUserSeeAllPresentableListener{
-
+    func willDisplay(at indexPath: IndexPath) {
+        
+    }
+    
+    
     weak var router: SearchUserSeeAllRouting?
     weak var listener: SearchUserSeeAllListener?
-
-    private let dependency: SearchUserSeeAllInteractorDependency
     
-    private var cancelTaskBag: CancelBag = .init()
+    private let dependency: SearchUserSeeAllInteractorDependency
+    private let cancelBag = CancelBag()
+    private var models: [UserSmallTableViewCellModel] = []
+    private var isLoading = false
     
     init(
         presenter: SearchUserSeeAllPresentable,
@@ -49,32 +52,16 @@ final class SearchUserSeeAllInteractor: PresentableInteractor<SearchUserSeeAllPr
         super.init(presenter: presenter)
         presenter.listener = self
     }
-
+    
     override func didBecomeActive() {
         super.didBecomeActive()
         presenter.updateTitle("사용자 검색")
-        Task { [weak self] in
-            guard let self else { return }
-            await self.dependency.searchUserSeeAllUseCase
-                .fetchUser(searchText: self.dependency.searchText)
-                .onSuccess(on: .main, with: self) { this, models in
-                    this.presenter.setup(models: models.map {
-                        UserSmallTableViewCellModel(
-                            userId: $0.userId,
-                            username: $0.username,
-                            profileUrl: $0.profileUrl
-                        )
-                    })
-                }
-                .onFailure { error in
-                    Log.make(message:"\(String(describing: self)) \(error.localizedDescription)", log: .network)
-                }
-        }.store(in: cancelTaskBag)
+        fetchUser()
     }
-
+    
     override func willResignActive() {
         super.willResignActive()
-        cancelTaskBag.cancel()
+        cancelBag.cancel()
     }
     
     func didTapClose() {
@@ -83,6 +70,71 @@ final class SearchUserSeeAllInteractor: PresentableInteractor<SearchUserSeeAllPr
     
     func didTapItem(model: UserSmallTableViewCellModel) {
         listener?.didTapUser(userId: model.userId)
+    }
+    
+    private func fetchUser() {
+        startLoading()
+        
+        Task { [weak self] in
+            guard let self else { return }
+            await dependency.searchUserSeeAllUseCase
+                .fetchUser(searchText: dependency.searchText)
+                .onSuccess(on: .main, with: self) { this, users in
+                    let models = users.toModels()
+                    this.models = models
+                    this.presenter.setup(models: models)
+                    this.stopLoading()
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: error.localizedDescription, log: .interactor)
+                    this.stopLoading()
+                }
+        }.store(in: cancelBag)
+    }
+    
+    private func loadMoreIfNeeded() {
+        guard dependency.searchUserSeeAllUseCase.hasMoreUser, isLoading == false else { return }
+        startLoading()
+        
+        Task { [weak self] in
+            guard let self else { return }
+            await dependency.searchUserSeeAllUseCase
+                .loadMoreUser(searchText: dependency.searchText)
+                .onSuccess(on: .main, with: self) { this, users in
+                    let models = users.toModels()
+                    this.models.append(contentsOf: models)
+                    this.presenter.append(models: models)
+                    this.stopLoading()
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: error.localizedDescription, log: .interactor)
+                    this.stopLoading()
+                }
+        }.store(in: cancelBag)
+    }
+    
+    private func startLoading() {
+        isLoading = true
+        presenter.startLoading()
+    }
+    
+    private func stopLoading() {
+        isLoading = false
+        presenter.stopLoading()
+    }
+    
+}
+
+private extension Array where Element == SearchUser {
+    
+    func toModels() -> [UserSmallTableViewCellModel] {
+        return map {
+            return .init(
+                userId: $0.userId,
+                username: $0.username,
+                profileUrl: $0.profileUrl
+            )
+        }
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SeeAll/User/SearchUserSeeAllInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SeeAll/User/SearchUserSeeAllInteractor.swift
@@ -57,8 +57,8 @@ final class SearchUserSeeAllInteractor: PresentableInteractor<SearchUserSeeAllPr
             guard let self else { return }
             await self.dependency.searchUserSeeAllUseCase
                 .fetchUser(searchText: self.dependency.searchText)
-                .onSuccess(on: .main, with: self) { _, models in
-                    self.presenter.setup(models: models.map {
+                .onSuccess(on: .main, with: self) { this, models in
+                    this.presenter.setup(models: models.map {
                         UserSmallTableViewCellModel(
                             userId: $0.userId,
                             username: $0.username,

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapSearchView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapSearchView.swift
@@ -1,0 +1,70 @@
+//
+//  SearchMapSearchView.swift
+//  SearchImplementations
+//
+//  Created by 홍성준 on 12/11/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import DesignKit
+
+final class SearchMapSearchView: UIView {
+    
+    private enum Constant {
+        static let searchImageName = "magnifyingglass"
+    }
+    
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(systemName: Constant.searchImageName)?.withRenderingMode(.alwaysTemplate)
+        imageView.tintColor = .hpBlack
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private let placeholderLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyRegular
+        label.textColor = .hpGray2
+        label.text = "위치, 장소 검색"
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+}
+
+private extension SearchMapSearchView {
+    
+    func setupViews() {
+        backgroundColor = .hpWhite
+        layer.borderWidth = 1
+        layer.borderColor = UIColor.hpGray3.cgColor
+        
+        [imageView, placeholderLabel].forEach(addSubview)
+        
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 15),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 20),
+            imageView.heightAnchor.constraint(equalToConstant: 20),
+            
+            placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: 13),
+            placeholderLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 10),
+            placeholderLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            placeholderLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -13)
+        ])
+    }
+    
+}


### PR DESCRIPTION
## 🌁 배경
* close #635 
* 검색 쪽 버그 작업 했습니다.
* 지도 홈 화면에서 검색 TextField가 TextField라서 실제 텍스트가 입력이 되는 버그가 있어 View로 변경했습니다.
* 재검색이 스크롤을 너무 많이 해야 한다는 얘기가 있어서 조금해도 등장할 수 있도록 수치를 변경했습니다.

## ✅ 수정 내역
* 검색 결과 모두 보기 기능 추가 (스토리, 유저)
* 스토리/유저 모두 보기 페이징 처리 추가
* 유저 모두 보기 UI 변경
* 기타 레이아웃 변경
* 지도 홈 화면 검색 TextField 대신 View로 대체
* 재검색 active 값 수정

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/e44d424c-22d6-4801-a1d9-6222735de388

https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/5a2f126f-0c77-4599-ae0e-67c426d9986b


