### PR TITLE
홈 탭 QA

### DIFF
--- a/client/Targets/Domain/Entities/Sources/Home/HomeFollowingStory.swift
+++ b/client/Targets/Domain/Entities/Sources/Home/HomeFollowingStory.swift
@@ -43,3 +43,11 @@ public struct HomeFollowingStory {
     }
     
 }
+
+extension HomeFollowingStory: Equatable {
+    
+    public static func == (lhs: HomeFollowingStory, rhs: HomeFollowingStory) -> Bool {
+        return lhs.storyId == rhs.storyId
+    }
+    
+}

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardInteractor.swift
@@ -34,6 +34,8 @@ final class HomeFollowingDashboardInteractor: PresentableInteractor<HomeFollowin
     
     private let dependency: HomeFollowingDashboardInteractorDependency
     private let cancelBag = CancelBag()
+    private var isInitialAppear = true
+    private var stories: [HomeFollowingStory] = []
     
     init(presenter: HomeFollowingDashboardPresentable, dependency: HomeFollowingDashboardInteractorDependency) {
         self.dependency = dependency
@@ -59,6 +61,14 @@ final class HomeFollowingDashboardInteractor: PresentableInteractor<HomeFollowin
         listener?.followingDashboardDidTapStory(id: storyId)
     }
     
+    func didAppear() {
+        if isInitialAppear {
+            isInitialAppear = false
+            return
+        }
+        fetchFollowing()
+    }
+    
     private func fetchFollowing() {
         Task { [weak self] in
             guard let self else { return }
@@ -66,11 +76,14 @@ final class HomeFollowingDashboardInteractor: PresentableInteractor<HomeFollowin
                 .onSuccess(on: .main, with: self) { this, storeis in
                     this.performAfterFetchingFollowing(stories: storeis)
                 }
-            
         }.store(in: cancelBag)
     }
     
     private func performAfterFetchingFollowing(stories: [HomeFollowingStory]) {
+        guard self.stories != stories else {
+            return
+        }
+        self.stories = stories
         let model = makeModels(stories: stories)
         presenter.setup(model: model)
     }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardViewController.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardViewController.swift
@@ -18,6 +18,7 @@ struct HomeFollowingDashboardViewModel {
 protocol HomeFollowingDashboardPresentableListener: AnyObject {
     func didTapSeeAll()
     func didTap(storyId: Int)
+    func didAppear()
 }
 
 final class HomeFollowingDashboardViewController: UIViewController, HomeFollowingDashboardPresentable, HomeFollowingDashboardViewControllable {
@@ -27,7 +28,11 @@ final class HomeFollowingDashboardViewController: UIViewController, HomeFollowin
     private enum Constant {
         static let title = "팔로잉"
         static let contentSpacing: CGFloat = 20
+        static let emptyViewHeight: CGFloat = 80
     }
+    
+    private var scrollViewBottomConstraint: NSLayoutConstraint?
+    private var emptyViewBottomConstraint: NSLayoutConstraint?
     
     private lazy var titleView: SeeAllView = {
         let titleView = SeeAllView()
@@ -75,14 +80,24 @@ final class HomeFollowingDashboardViewController: UIViewController, HomeFollowin
         setupViews()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        listener?.didAppear()
+    }
+    
     func setup(model: HomeFollowingDashboardViewModel) {
         let isEmpty = model.contentList.isEmpty
         titleView.setup(model: .init(
             title: Constant.title,
             isButtonEnabled: !isEmpty
         ))
+        
         emptyView.isHidden = !isEmpty
+        emptyViewBottomConstraint?.isActive = isEmpty
+        
         scrollView.isHidden = isEmpty
+        scrollViewBottomConstraint?.isActive = !isEmpty
+        
         model.contentList.forEach { contentModel in
             let contentView = HomeFollowingContentView()
             contentView.delegate = self
@@ -117,6 +132,12 @@ private extension HomeFollowingDashboardViewController {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
         
+        scrollViewBottomConstraint = scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        scrollViewBottomConstraint?.isActive = true
+        
+        emptyViewBottomConstraint = emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        emptyViewBottomConstraint?.isActive = true
+        
         NSLayoutConstraint.activate([
             titleView.topAnchor.constraint(equalTo: view.topAnchor),
             titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
@@ -125,7 +146,7 @@ private extension HomeFollowingDashboardViewController {
             emptyView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: Constant.contentSpacing),
             emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
             emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
-            emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyView.heightAnchor.constraint(equalToConstant: Constant.emptyViewHeight),
             
             scrollView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: Constant.contentSpacing),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardViewController.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/HotPlaceDashboard/HomeHotPlaceDashboardViewController.swift
@@ -81,7 +81,7 @@ final class HomeHotPlaceDashboardViewController: UIViewController, HomeHotPlaceD
     func setup(model: HomeHotPlaceDashboardViewModel) {
         let isEmpty = model.contentList.isEmpty
         titleView.setup(model: .init(
-            title: isEmpty ? Constant.emptyTitle : Constant.title,
+            title: Constant.title,
             isButtonEnabled: !isEmpty
         ))
         emptyView.isHidden = !isEmpty


### PR DESCRIPTION
## 🌁 배경
* close #659 
* 팔로잉 쪽은 storyId를 통해 Equatable을 준수시켜서 현재 저장된 팔로잉 스토리들과 동일한 응답을 받으면 새로고침을 하지 않습니다

## ✅ 수정 내역
* 핫플레이스 없을 때 타이틀이 '핫플레이스가 없어요' 되는 문제 제거
* 홈 팔로잉 탭 새로고침 추가

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/1b30c6ff-e938-4fb7-bba3-c02be7541115

