### PR TITLE
자잘한 버그 수정

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootTabBarController.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootTabBarController.swift
@@ -18,7 +18,7 @@ final class AppRootTabBarController: UITabBarController, AppRootPresentable, App
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .hpWhite
         setupTabBar()
     }
     

--- a/client/Targets/Core/FoundationKit/Sources/Alert/AlertType.swift
+++ b/client/Targets/Core/FoundationKit/Sources/Alert/AlertType.swift
@@ -24,6 +24,8 @@ public enum AlertType {
     case didFailToLike
     case didFailToLoadComments
     case didFailToSaveComment
+    case didFailToImageLoad
+    
 }
 
 extension AlertType {
@@ -44,6 +46,7 @@ extension AlertType {
         case .didFailToLike: return "좋아요/좋아요 취소 실패"
         case .didFailToLoadComments: return "댓글 정보 획득 실패"
         case .didFailToSaveComment: return "댓글 작성 실패"
+        case .didFailToImageLoad: return "이미지 로드 실패"
         }
     }
     
@@ -63,6 +66,7 @@ extension AlertType {
         case .didFailToLike: return "좋아요/좋아요 취소에 실패했어요."
         case .didFailToLoadComments: return "댓글을 불러오는데 실패했어요.\n 확인 버튼을 누르면 이전화면으로 이동해요."
         case .didFailToSaveComment: return "댓글 작성에 실패했어요.\n 다시 시도하시겠어요?"
+        case .didFailToImageLoad: return "지원하지 않는 이미지 타입이에요."
         }
     }
     
@@ -82,6 +86,7 @@ extension AlertType {
         case .didFailToLike: return false
         case .didFailToLoadComments: return false
         case .didFailToSaveComment: return true
+        case .didFailToImageLoad: return false
         }
     }
     

--- a/client/Targets/Data/Repositories/Sources/ClusteringOperation.swift
+++ b/client/Targets/Data/Repositories/Sources/ClusteringOperation.swift
@@ -47,8 +47,6 @@ final class ClusteringOperation: Operation {
         )
     }
     
-    // TODO: - FullBound 영점 조절
-    
     private func makeCluster(
         bound: LocationBound,
         placeBound: LocationBound,
@@ -56,10 +54,10 @@ final class ClusteringOperation: Operation {
     ) -> [Cluster] {
         let latScope = (bound.northEast.lat - bound.southWest.lat) / Double(sliceLat)
         let lngScope = (bound.northEast.lng - bound.southWest.lng) / Double(sliceLng)
-//        let fullBound = makeFullBound(bound: bound, placeBound: placeBound)
+        let adjustPlaceBound = adjustPlaceBound(placeBound)
         
         var clusters = makeInitialClusters(
-            fullBound: placeBound,
+            fullBound: adjustPlaceBound,
             latScope: latScope,
             lngScope: lngScope
         )
@@ -102,6 +100,43 @@ final class ClusteringOperation: Operation {
         let minLng = min(bound.southWest.lng, placeBound.southWest.lng)
         let maxLat = max(bound.northEast.lat, placeBound.northEast.lat)
         let maxLng = max(bound.northEast.lng, placeBound.northEast.lng)
+        
+        return LocationBound.init(
+            southWest: .init(lat: minLat, lng: minLng),
+            northEast: .init(lat: maxLat, lng: maxLng)
+        )
+    }
+    
+    private func adjustPlaceBound(_ placeBound: LocationBound) -> LocationBound {
+        let adjustment = 0.00000000000010 // 총 자리수 XXX.XXXXXXXXXXXXXX
+        
+        let minLat: Double = {
+            guard placeBound.southWest.lat == placeBound.northEast.lat else {
+                return placeBound.southWest.lat
+            }
+            return placeBound.southWest.lat - adjustment
+        }()
+        
+        let minLng: Double = {
+            guard placeBound.southWest.lng == placeBound.northEast.lng else {
+                return placeBound.southWest.lng
+            }
+            return placeBound.southWest.lng - adjustment
+        }()
+        
+        let maxLat: Double = {
+            guard placeBound.southWest.lat == placeBound.northEast.lat else {
+                return placeBound.northEast.lat
+            }
+            return placeBound.northEast.lat + adjustment
+        }()
+        
+        let maxLng: Double = {
+            guard placeBound.southWest.lng == placeBound.northEast.lng else {
+                return placeBound.northEast.lng
+            }
+            return placeBound.northEast.lng + adjustment
+        }()
         
         return LocationBound.init(
             southWest: .init(lat: minLat, lng: minLng),

--- a/client/Targets/Data/Repositories/Sources/ClusteringService.swift
+++ b/client/Targets/Data/Repositories/Sources/ClusteringService.swift
@@ -31,8 +31,7 @@ public final class ClusteringService: ClusteringServiceInterface {
         clusteringQueue.addOperation(operation)
         
         operation.completionBlock = { [weak self] in
-            guard let clusters = operation.clusters
-            else {
+            guard let clusters = operation.clusters else {
                 return
             }
             self?.clusteringCompletionBlock?(clusters)

--- a/client/Targets/Data/Repositories/Sources/LocationService.swift
+++ b/client/Targets/Data/Repositories/Sources/LocationService.swift
@@ -97,7 +97,8 @@ extension LocationService: CLLocationManagerDelegate {
     
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.first else { return }
-        locationSubject.send(location.coordinate.toEntity())
+        let coordinate = location.coordinate.toEntity()
+        locationSubject.send(coordinate)
         stopUpdatingLocation()
     }
     

--- a/client/Targets/DesignSystem/DesignKit/Sources/TextFields/SearchTextField.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/TextFields/SearchTextField.swift
@@ -40,7 +40,7 @@ private extension SearchTextField {
     
     func setupViews() {
         font = .captionRegular
-        backgroundColor = .white
+        backgroundColor = .hpWhite
         layer.borderWidth = 1
         layer.borderColor = UIColor.hpGray3.cgColor
         setupSearchLeftView()

--- a/client/Targets/DesignSystem/DesignKit/Sources/Views/NavigationView.swift
+++ b/client/Targets/DesignSystem/DesignKit/Sources/Views/NavigationView.swift
@@ -102,7 +102,7 @@ public final class NavigationView: UIView {
 private extension NavigationView {
     
     func setupViews() {
-        backgroundColor = .white
+        backgroundColor = .hpWhite
         [titleLabel, leftButton, rightButtonStackView, separator].forEach(addSubview)
         
         NSLayoutConstraint.activate([

--- a/client/Targets/Domain/Entities/Sources/Home/RecommendPlace.swift
+++ b/client/Targets/Domain/Entities/Sources/Home/RecommendPlace.swift
@@ -19,3 +19,11 @@ public struct RecommendPlace {
     }
     
 }
+
+extension RecommendPlace: Equatable {
+    
+    public static func == (lhs: RecommendPlace, rhs: RecommendPlace) -> Bool {
+        lhs.title == rhs.title && lhs.stories == rhs.stories
+    }
+    
+}

--- a/client/Targets/Domain/Entities/Sources/Home/RecommendStory.swift
+++ b/client/Targets/Domain/Entities/Sources/Home/RecommendStory.swift
@@ -40,3 +40,11 @@ public struct RecommendStory {
     }
     
 }
+
+extension RecommendStory: Equatable {
+    
+    public static func == (lhs: RecommendStory, rhs: RecommendStory) -> Bool {
+        lhs.id == rhs.id
+    }
+    
+}

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignIn/SignInViewController.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignIn/SignInViewController.swift
@@ -69,7 +69,7 @@ private extension SignInViewController {
     }
     
     func setupViews() {
-        view.backgroundColor = .white
+        view.backgroundColor = .hpWhite
         [logoImageView, githubLoginButton, naverLoginButton].forEach { view.addSubview($0) }
         
         let padding: CGFloat = 20

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpViewController.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpViewController.swift
@@ -26,7 +26,6 @@ final class SignUpViewController: BaseViewController, SignUpPresentable, SignUpV
         static let imageHeight: CGFloat = 100
         
         enum AvailableUsernameLabel {
-            static let title = "변경할 닉네임을 입력해주세요"
             static let overlap = "중복된 닉네임입니다."
             static let possible = "사용가능한 닉네임입니다."
         }
@@ -42,7 +41,7 @@ final class SignUpViewController: BaseViewController, SignUpPresentable, SignUpV
     
     func updateButtonEnabled(_ isEnabled: Bool) {
         signUpButton.isEnabled = isEnabled
-        availableUsernameLabel.text = Constant.AvailableUsernameLabel.title
+        availableUsernameLabel.text = nil
     }
     
     func updateAvailableUsernameLabel(_ available: Bool) {
@@ -136,7 +135,6 @@ final class SignUpViewController: BaseViewController, SignUpPresentable, SignUpV
         }
         
         availableUsernameLabel.do {
-            $0.text = Constant.AvailableUsernameLabel.title
             $0.textColor = .hpGray1
             $0.font = .smallRegular
             $0.translatesAutoresizingMaskIntoConstraints = false

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpViewController.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpViewController.swift
@@ -26,9 +26,9 @@ final class SignUpViewController: BaseViewController, SignUpPresentable, SignUpV
         static let imageHeight: CGFloat = 100
         
         enum AvailableUsernameLabel {
-            static let title = "변경할 유저이름을 입력해주세요"
-            static let overlap = "중복된 유저이름입니다."
-            static let possible = "사용가능한 유저이름입니다."
+            static let title = "변경할 닉네임을 입력해주세요"
+            static let overlap = "중복된 닉네임입니다."
+            static let possible = "사용가능한 닉네임입니다."
         }
     }
     
@@ -107,14 +107,14 @@ final class SignUpViewController: BaseViewController, SignUpPresentable, SignUpV
         }
         
         usernameLabel.do {
-            $0.text = "유저이름"
+            $0.text = "닉네임"
             $0.font = .largeSemibold
             $0.textColor = .hpBlack
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
         usernameTextField.do {
-            $0.placeholder = "유저이름을 입력하세요"
+            $0.placeholder = "닉네임을 입력하세요"
             $0.font = .bodyRegular
             $0.textColor = .hpBlack
             $0.borderStyle = .roundedRect

--- a/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpViewController.swift
+++ b/client/Targets/Presentation/Auth/Implementations/Sources/SignUp/SignUpViewController.swift
@@ -174,18 +174,24 @@ extension SignUpViewController: PHPickerViewControllerDelegate {
         guard let itemProvider = results.first?.itemProvider,
               itemProvider.canLoadObject(ofClass: UIImage.self)
         else {
-            // TODO: Handle empty results or item provider not being able load UIImage
+            showUnsupportedImageType()
             return
         }
         
         itemProvider.loadObject(ofClass: UIImage.self) { image, _ in
             DispatchQueue.main.async { [weak self] in
-                guard let image = image as? UIImage,
-                      let imageData = image.pngData() else { return }
+                guard let image = image as? UIImage, let imageData = image.pngData() else {
+                    self?.showUnsupportedImageType()
+                    return
+                }
                 self?.profileImageView.image = image
                 self?.listener?.profileImageViewDidChange(imageData)
             }
         }
+    }
+    
+    private func showUnsupportedImageType() {
+        present(type: .didFailToImageLoad) {}
     }
     
 }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardViewController.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/FollowingDashboard/HomeFollowingDashboardViewController.swift
@@ -151,7 +151,6 @@ private extension HomeFollowingDashboardViewController {
             scrollView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: Constant.contentSpacing),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             
             stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardInteractor.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardInteractor.swift
@@ -37,7 +37,8 @@ final class HomeRecommendDashboardInteractor: PresentableInteractor<HomeRecommen
     private let dependency: HomeRecommendDashboardInteractorDependency
     private let cancelBag = CancelBag()
     private var cancellables = Set<AnyCancellable>()
-
+    private var place: RecommendPlace?
+    
     init(
         presenter: HomeRecommendDashboardPresentable,
         dependency: HomeRecommendDashboardInteractorDependency
@@ -77,6 +78,10 @@ final class HomeRecommendDashboardInteractor: PresentableInteractor<HomeRecommen
     }
     
     private func performAfterFecthingRecommendPlace(place: RecommendPlace) {
+        if self.place == place {
+            return
+        }
+        self.place = place
         let model = makeModel(place: place)
         presenter.setup(model: model)
     }

--- a/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardViewController.swift
+++ b/client/Targets/Presentation/Home/Implementations/Sources/Home/RecommendDashboard/HomeRecommendDashboardViewController.swift
@@ -31,7 +31,11 @@ final class HomeRecommendDashboardViewController: UIViewController, HomeRecommen
         static let emptySubtitle = "스토리를 작성하시면 추천 장소가 될 수 있어요"
         static let spacing: CGFloat = 20
         static let contentSpacing: CGFloat = 10
+        static let emptyViewHeight: CGFloat = 80
     }
+    
+    private var scrollViewBottomConstraint: NSLayoutConstraint?
+    private var emptyViewBottomConstraint: NSLayoutConstraint?
     
     private lazy var titleView: SeeAllView = {
         let titleView = SeeAllView()
@@ -88,8 +92,13 @@ final class HomeRecommendDashboardViewController: UIViewController, HomeRecommen
         let isEmpty = model.contentList.isEmpty
         titleView.setup(model: .init(title: model.title, isButtonEnabled: !isEmpty))
         stackView.subviews.forEach { $0.removeFromSuperview() }
+        
         emptyView.isHidden = !isEmpty
+        emptyViewBottomConstraint?.isActive = isEmpty
+        
         scrollView.isHidden = isEmpty
+        scrollViewBottomConstraint?.isActive = !isEmpty
+        
         model.contentList.forEach { contentModel in
             let contentView = HomeRecommendContentView()
             contentView.addTapGesture(target: self, action: #selector(contentViewDidTap))
@@ -130,6 +139,12 @@ private extension HomeRecommendDashboardViewController {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
         
+        scrollViewBottomConstraint = scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        scrollViewBottomConstraint?.isActive = true
+        
+        emptyViewBottomConstraint = emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        emptyViewBottomConstraint?.isActive = true
+        
         NSLayoutConstraint.activate([
             titleView.topAnchor.constraint(equalTo: view.topAnchor),
             titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
@@ -138,12 +153,11 @@ private extension HomeRecommendDashboardViewController {
             emptyView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: Constant.spacing),
             emptyView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.leadingOffset),
             emptyView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
-            emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyView.heightAnchor.constraint(equalToConstant: Constant.emptyViewHeight),
             
             scrollView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: Constant.spacing),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             
             stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UpdateUserDashboard/MyProfileUpdateUserDashboardViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UpdateUserDashboard/MyProfileUpdateUserDashboardViewController.swift
@@ -8,12 +8,11 @@
 
 import UIKit
 import PhotosUI
-
 import ModernRIBs
-
-import BasePresentation
+import CoreKit
 import DesignKit
 import DomainEntities
+import BasePresentation
 
 protocol MyProfileUpdateUserDashboardPresentableListener: AnyObject {
     func didTapBack()
@@ -190,16 +189,26 @@ extension MyProfileUpdateUserDashboardViewController: PHPickerViewControllerDele
         picker.dismiss(animated: true)
         
         guard let itemProvider = results.first?.itemProvider,
-              itemProvider.canLoadObject(ofClass: UIImage.self) else { return }
+                itemProvider.canLoadObject(ofClass: UIImage.self)
+        else {
+            showUnsupportedImageType()
+            return
+        }
         
         itemProvider.loadObject(ofClass: UIImage.self) { image, _ in
             DispatchQueue.main.async { [weak self] in
-                guard let image = image as? UIImage,
-                      let imageData = image.pngData() else { return }
+                guard let image = image as? UIImage, let imageData = image.pngData() else {
+                    self?.showUnsupportedImageType()
+                    return
+                }
                 self?.headerView.myPageUpdateUserProfileViewSetup(image: image)
                 self?.listener?.profileImageViewDidChange(imageData)
             }
         }
+    }
+    
+    private func showUnsupportedImageType() {
+        present(type: .didFailToImageLoad) {}
     }
     
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UpdateUserDashboard/Views/MyProfileUpdateUserBasicInformationView.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UpdateUserDashboard/Views/MyProfileUpdateUserBasicInformationView.swift
@@ -32,9 +32,9 @@ final class MyProfileUpdateUserBasicInformationView: UIView {
         }
         
         enum AvailableUsernameLabel {
-            static let title = "변경할 유저이름을 입력해주세요"
-            static let overlap = "중복된 유저이름입니다."
-            static let possible = "사용가능한 유저이름입니다."
+            static let title = "변경할 닉네임을 입력해주세요"
+            static let overlap = "중복된 닉네임입니다."
+            static let possible = "사용가능한 닉네임입니다."
         }
     }
     

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserDashboard/UserProfileUserDashboardViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserDashboard/UserProfileUserDashboardViewController.swift
@@ -74,7 +74,6 @@ final class UserProfileUserDashboardViewController: UIViewController, UserProfil
     func updateFollow(_ isFollow: Bool) {
         userView.updateFollowButton(isFollow)
     }
-
     
 }
 

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileInteractor.swift
@@ -27,7 +27,7 @@ protocol UserProfileRouting: ViewableRouting {
 protocol UserProfilePresentable: Presentable {
     var listener: UserProfilePresentableListener? { get set }
     
-    func setupNavi(_ username: String)
+    func setupTitle(_ username: String)
 }
 
 protocol UserProfileInteractorDependency: AnyObject {
@@ -96,7 +96,7 @@ final class UserProfileInteractor: PresentableInteractor<UserProfilePresentable>
                 .fetchUserProfile(userId: dependency.userId)
                 .onSuccess(on: .main, with: self) { this, profile in
                     this.profile = profile
-                    this.presenter.setupNavi(profile.userName)
+                    this.presenter.setupTitle(profile.userName)
                 }
                 .onFailure { error in
                     Log.make(message: error.localizedDescription, log: .interactor)

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileViewController.swift
@@ -22,24 +22,11 @@ final class UserProfileViewController: BaseViewController, UserProfilePresentabl
     weak var listener: UserProfilePresentableListener?
     
     private enum Constant {
-        static let tabBarTitle = "마이"
-        static let tabBarImage = "person"
-        static let tabBarImageSelected = "person.fill"
         static let contentInset: UIEdgeInsets = .init(top: 20, left: 0, bottom: 20, right: 0)
     }
     
     private let scrollView = UIScrollView()
     private let stackView = UIStackView()
-    
-    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        setupTabBar()
-    }
-    
-    required public init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setupTabBar()
-    }
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -86,7 +73,6 @@ final class UserProfileViewController: BaseViewController, UserProfilePresentabl
         view.backgroundColor = .hpWhite
                 
         scrollView.do {
-            $0.contentInset = .zero
             $0.showsHorizontalScrollIndicator = false
             $0.showsVerticalScrollIndicator = false
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -107,7 +93,7 @@ final class UserProfileViewController: BaseViewController, UserProfilePresentabl
         }
     }
     
-    func setupNavi(_ username: String) {
+    func setupTitle(_ username: String) {
         navigationView.do {
             $0.setup(model: .init(
                 title: "\(username)",
@@ -123,18 +109,6 @@ extension UserProfileViewController: NavigationViewDelegate {
     
     public func navigationViewButtonDidTap(_ view: NavigationView, type: NavigationViewButtonType) {
         if case .back = type { listener?.didTapBack() }
-    }
-    
-}
-
-private extension UserProfileViewController {
-    
-    func setupTabBar() {
-        tabBarItem = .init(
-            title: Constant.tabBarTitle,
-            image: UIImage(systemName: Constant.tabBarImage)?.withRenderingMode(.alwaysTemplate),
-            selectedImage: UIImage(systemName: Constant.tabBarImageSelected)?.withRenderingMode(.alwaysTemplate)
-        )
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -172,6 +172,8 @@ extension SearchInteractor: SearchPresentableListener {
             isInitialCameraMoved = true
             presenter.moveMap(lat: location.lat, lng: location.lng)
             fetchPlaces(lat: location.lat, lng: location.lng)
+        } else {
+            presenter.showReSearchView()
         }
     }
     

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -102,6 +102,8 @@ final class SearchInteractor: PresentableInteractor<SearchPresentable>,
     }
     
     func storyDidCreate(_ storyId: Int) {
+        presenter.deselectAll()
+        didTapReSearch()
         router?.detachStoryEditor { [weak self] in
             self?.router?.attachStoryDetail(storyId: storyId)
         }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/Views/SearchNavigationView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchResult/Views/SearchNavigationView.swift
@@ -83,7 +83,7 @@ public final class SearchNavigationView: UIView {
 private extension SearchNavigationView {
     
     func setupViews() {
-        backgroundColor = .white
+        backgroundColor = .hpWhite
         [backButton, searchTextField].forEach(addSubview)
         
         NSLayoutConstraint.activate([

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapReSearchView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchMapReSearchView.swift
@@ -52,7 +52,7 @@ final class SearchMapReSearchView: UIView {
 private extension SearchMapReSearchView {
     
     func setupViews() {
-        backgroundColor = .white
+        backgroundColor = .hpWhite
         layer.cornerRadius = Constants.cornerRadiusMedium
         layer.borderWidth = 1
         layer.borderColor = UIColor.hpBlue2.cgColor

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryCreateSuccess/Components/RollingCharView.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryCreateSuccess/Components/RollingCharView.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import DesignKit
 
 final class RollingCharView: UIView {
     private var items: [Character] = []
@@ -15,7 +16,7 @@ final class RollingCharView: UIView {
         let gradientLayer = CAGradientLayer()
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.25)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 0.0)
-        let baseColor = UIColor.white
+        let baseColor = UIColor.hpWhite
         gradientLayer.colors = [
             baseColor.withAlphaComponent(0),
             baseColor.withAlphaComponent(1),
@@ -28,7 +29,7 @@ final class RollingCharView: UIView {
         let gradientLayer = CAGradientLayer()
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.75)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
-        let baseColor = UIColor.white
+        let baseColor = UIColor.hpWhite
         gradientLayer.colors = [
             baseColor.withAlphaComponent(0),
             baseColor.withAlphaComponent(1),

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageField.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageField.swift
@@ -13,6 +13,7 @@ import DesignKit
 
 protocol ImageFieldDelegate: AnyObject {
     func imageDidAdd()
+    func imageDidFailToLoad()
     func imageDidRemove()
 }
 
@@ -120,12 +121,16 @@ extension ImageField: ImageSelectorDelegate {
         delegate?.imageDidAdd()
     }
     
+    func imageDidFailToLoad() {
+        delegate?.imageDidFailToLoad()
+    }
+    
     func imageDidRemove(from selector: ImageSelector) {
         selector.removeFromSuperview()
         delegate?.imageDidRemove()
         
         if let selector = stackView.arrangedSubviews.last as? ImageSelector,
-                selector.isSelected {
+           selector.isSelected {
             addImageSelector()
         }
     }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
@@ -27,7 +27,7 @@ final class ImageSelector: UIView {
     }
     weak var delegate: ImageSelectorDelegate?
     weak var presenterDelegate: ImageSelectorPickerPresenterDelegate?
-    private weak var picker: PHPickerViewController?
+    
     private var isLoading = false
     
     var isSelected: Bool {
@@ -120,14 +120,13 @@ private extension ImageSelector {
 private extension ImageSelector {
     
     @objc func addImageDidTap() {
-        guard picker == nil && !isLoading else { return }
+        guard !isLoading else { return }
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
         configuration.selectionLimit = 1
         configuration.filter = .images
         
         let picker = PHPickerViewController(configuration: configuration)
         picker.delegate = self
-        self.picker = picker
         presenterDelegate?.addImageDidTap(with: picker)
     }
     
@@ -161,8 +160,8 @@ extension ImageSelector: PHPickerViewControllerDelegate {
             loadLivePhoto(itemProvider)
         } else {
             delegate?.imageDidFailToLoad()
+            isLoading = false
         }
-        isLoading = false
     }
     
     private func loadUIImage(_ itemProvider: NSItemProvider) {
@@ -170,9 +169,11 @@ extension ImageSelector: PHPickerViewControllerDelegate {
             DispatchQueue.main.async { [weak self] in
                 guard let image = image as? UIImage, let self else {
                     self?.delegate?.imageDidFailToLoad()
+                    self?.isLoading = false
                     return
                 }
                 imageView.image = image
+                isLoading = false
                 changeToRemoveButton()
             }
         }
@@ -184,6 +185,7 @@ extension ImageSelector: PHPickerViewControllerDelegate {
                   let photo = PHAssetResource.assetResources(for: livePhoto).first(where: { $0.type == .photo })
             else {
                 self?.delegate?.imageDidFailToLoad()
+                self?.isLoading = false
                 return
             }
             
@@ -196,9 +198,11 @@ extension ImageSelector: PHPickerViewControllerDelegate {
                     DispatchQueue.main.async { [weak self] in
                         guard let self else {
                             self?.delegate?.imageDidFailToLoad()
+                            self?.isLoading = false
                             return
                         }
                         imageView.image = UIImage(data: imageData as Data)
+                        isLoading = false
                         changeToRemoveButton()
                     }
                 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/Components/ImageSelector.swift
@@ -11,6 +11,7 @@ import PhotosUI
 
 protocol ImageSelectorDelegate: AnyObject {
     func imageDidAdd()
+    func imageDidFailToLoad()
     func imageDidRemove(from selector: ImageSelector)
 }
 
@@ -19,7 +20,7 @@ protocol ImageSelectorPickerPresenterDelegate: AnyObject {
 }
 
 final class ImageSelector: UIView {
-
+    
     enum Constant {
         static let transparentBlack: UIColor = .init(red: 0, green: 0, blue: 0, alpha: 0.5)
         static let buttonWidthHeight: CGFloat = 44
@@ -119,7 +120,6 @@ private extension ImageSelector {
 private extension ImageSelector {
     
     @objc func addImageDidTap() {
-        plusImageView.isUserInteractionEnabled = false
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
         configuration.selectionLimit = 1
         configuration.filter = .images
@@ -146,40 +146,63 @@ extension ImageSelector: PHPickerViewControllerDelegate {
     
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true)
+        plusImageView.isUserInteractionEnabled = false
         
-        if let itemProvider = results.first?.itemProvider,
-              itemProvider.canLoadObject(ofClass: UIImage.self) {
-            
-            itemProvider.loadObject(ofClass: UIImage.self) { image, _ in
-                DispatchQueue.main.async { [weak self] in
-                    guard let image = image as? UIImage, let self else { return }
-                    imageView.image = image
-                    changeToRemoveButton()
-                }
-            }
+        guard let itemProvider = results.first?.itemProvider else {
+            plusImageView.isUserInteractionEnabled = true
             return
         }
         
-        if let livePhotoProgress = results.first?.itemProvider, livePhotoProgress.canLoadObject(ofClass: PHLivePhoto.self) {
-            livePhotoProgress.loadObject(ofClass: PHLivePhoto.self) { livePhoto, _ in
-                guard let livePhoto = livePhoto as? PHLivePhoto,
-                      let photo = PHAssetResource.assetResources(for: livePhoto).first(where: { $0.type == .photo }) else { return }
-                
-                let imageData = NSMutableData()
-                PHAssetResourceManager.default().requestData(for: photo, options: nil, dataReceivedHandler: { data in
-                    imageData.append(data)
-                }, completionHandler: { error in
-                    DispatchQueue.main.async { [weak self] in
-                        guard let self else { return }
-                        imageView.image = UIImage(data: imageData as Data)
-                        changeToRemoveButton()
-                    }
-                })
-            }
+        if itemProvider.canLoadObject(ofClass: UIImage.self) {
+            loadUIImage(itemProvider)
+        } else if itemProvider.canLoadObject(ofClass: PHLivePhoto.self) {
+            loadLivePhoto(itemProvider)
+        } else {
+            delegate?.imageDidFailToLoad()
         }
         
         plusImageView.isUserInteractionEnabled = true
-        
+    }
+    
+    private func loadUIImage(_ itemProvider: NSItemProvider) {
+        itemProvider.loadObject(ofClass: UIImage.self) { image, _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let image = image as? UIImage, let self else {
+                    self?.delegate?.imageDidFailToLoad()
+                    return
+                }
+                imageView.image = image
+                changeToRemoveButton()
+            }
+        }
+    }
+    
+    private func loadLivePhoto(_ itemProvider: NSItemProvider) {
+        itemProvider.loadObject(ofClass: PHLivePhoto.self) { [weak self] livePhoto, _ in
+            guard let livePhoto = livePhoto as? PHLivePhoto,
+                  let photo = PHAssetResource.assetResources(for: livePhoto).first(where: { $0.type == .photo })
+            else {
+                self?.delegate?.imageDidFailToLoad()
+                return
+            }
+            
+            let imageData = NSMutableData()
+            PHAssetResourceManager.default().requestData(
+                for: photo,
+                options: nil,
+                dataReceivedHandler: { _ in },
+                completionHandler: { _ in
+                    DispatchQueue.main.async { [weak self] in
+                        guard let self else {
+                            self?.delegate?.imageDidFailToLoad()
+                            return
+                        }
+                        imageView.image = UIImage(data: imageData as Data)
+                        changeToRemoveButton()
+                    }
+                }
+            )
+        }
     }
     
 }

--- a/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
+++ b/client/Targets/Presentation/Story/Implementations/Sources/StoryEditor/StoryEditorViewController.swift
@@ -8,14 +8,12 @@
 
 import UIKit
 import PhotosUI
-
 import ModernRIBs
-
 import CoreKit
+import FoundationKit
 import DesignKit
 import DomainEntities
 import BasePresentation
-import FoundationKit
 
 protocol StoryEditorPresentableListener: AnyObject {
     func didTapClose()
@@ -232,6 +230,10 @@ extension StoryEditorViewController: ImageFieldDelegate {
     
     func imageDidAdd() {
         listener?.imageDidAdd()
+    }
+    
+    func imageDidFailToLoad() {
+        present(type: .didFailToImageLoad) {}
     }
     
     func imageDidRemove() {


### PR DESCRIPTION
## 🌁 배경
* close #663

## ✅ 수정 내역
* 회원가입 닉네임 default 설명 제거 (placeholder에 적힌 것과 중복되어 제거)
* 이미지 로드 실패 추가 (사진첩에서 로드 실패 시 alert 띄움)
* 스토리 작성 버그 수정 (버튼 userInteraction에 대한 enabled/disabled 로직 변경)
* 지도에 핀 1개 있을 때 클러스터링 안되는 버그 수정
* 스토리 작성 후 새로고침 추가

## 📕 리뷰 노트
#### 스토리 작성 버그 수정 (버튼 userInteraction에 대한 enabled/disabled 로직 변경)
* ImagePicker를 드래그로 dismiss하면 +버튼이 눌리지 않는 버그
* enabled/disabled 순서를 탭되었을 때가 아닌 Picker가 dismiss 된 시점과 이미지 로드가 끝난 시점으로 변경

#### 지도에 핀 1개 있을 때 클러스터링 안되는 버그 수정
* 핀이 1개 있을 때 남서/북동 으로 이루어진 좌표가 동일해서 범위를 잡지 못했음
* 조정 값을 추가하여 만약 남서/북동의 lat/lng 값이 동일하면 약간의 패딩을 주어서 해결

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/9749212d-880e-4b2e-8ae6-cfa1a66c31a0

