### PR TITLE
스토리 생성 가이드 추가

### DIFF
--- a/client/Targets/Core/FoundationKit/Sources/UserDefaults/UserDefaults+Key.swift
+++ b/client/Targets/Core/FoundationKit/Sources/UserDefaults/UserDefaults+Key.swift
@@ -15,6 +15,7 @@ public extension UserDefaults {
         case remoteNotification
         case initialSignInDate
         case recentSearch
+        case firstStoryGuideDidShow // 지도 화면 스토리 가이드 보여짐 여부
         
     }
     

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchMap/SearchMapUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Search/SearchMap/SearchMapUseCaseInterface.swift
@@ -11,9 +11,11 @@ import Combine
 import DomainEntities
 
 public protocol SearchMapUseCaseInterface {
+    var storyGuideDidShow: Bool { get }
     var location: LocationCoordinate? { get }
     var recommendPlaces: AnyPublisher<[Cluster], Never> { get }
     func fetchRecommendPlace(lat: Double, lng: Double) async -> Result<[Place], Error>
     func fetchRecommendPlace(lat: Double, lng: Double)
     func boundaryUpdated(zoomLevel: Double, boundary: LocationBound)
+    func storyGuideComplete()
 }

--- a/client/Targets/Domain/UseCases/Sources/SearchUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/SearchUseCase.swift
@@ -31,6 +31,10 @@ public final class SearchUseCase: SearchUseCaseInterface {
         return !isUserLastPage
     }
     
+    public var storyGuideDidShow: Bool {
+        return UserDefaults.standard.bool(forKey: .firstStoryGuideDidShow)
+    }
+    
     private let repository: SearchRepositoryInterface
     private let locationService: LocationServiceInterface
     private let clusteringService: ClusteringServiceInterface
@@ -165,6 +169,10 @@ public final class SearchUseCase: SearchUseCaseInterface {
     
     public func requestLocality(lat: Double, lng: Double) async -> String? {
         await locationService.requestLocality(lat: lat, lng: lng)
+    }
+    
+    public func storyGuideComplete() {
+        UserDefaults.standard.setValue(true, forKey: .firstStoryGuideDidShow)
     }
     
     private func registerClusteringCompletionBlock() {

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchInteractor.swift
@@ -46,8 +46,8 @@ protocol SearchPresentable: Presentable {
     func showReSearchView()
     func hideReSearchView()
     func deselectAll()
+    func showStoryGuideView()
 }
-
 
 final class SearchInteractor: PresentableInteractor<SearchPresentable>,
                               AdaptivePresentationControllerDelegate,
@@ -167,6 +167,8 @@ extension SearchInteractor: SearchPresentableListener {
     }
     
     func didAppear() {
+        showStoryGuideIfNeeded()
+        
         if !isInitialCameraMoved {
             let location = dependency.searchUseCase.location ?? .init(lat: 37.3588501438082, lng: 127.1052074432373)
             isInitialCameraMoved = true
@@ -283,11 +285,6 @@ extension SearchInteractor: SearchPresentableListener {
         }
     }
     
-    private func receiveAfterRecommendClusters(_ clusters: [Cluster]) {
-        presenter.removeAllMarker()
-        presenter.updateMarkers(clusters: clusters)
-    }
-    
 }
 
 private extension SearchInteractor {
@@ -305,6 +302,19 @@ private extension SearchInteractor {
         guard let fetchedLocation else { return false }
         let distance = abs(fetchedLocation.lat - location.lat) + abs(fetchedLocation.lng - location.lng)
         return distance >= 0.005
+    }
+    
+    func receiveAfterRecommendClusters(_ clusters: [Cluster]) {
+        presenter.removeAllMarker()
+        presenter.updateMarkers(clusters: clusters)
+    }
+    
+    func showStoryGuideIfNeeded() {
+        guard dependency.searchUseCase.storyGuideDidShow == false else {
+            return
+        }
+        presenter.showStoryGuideView()
+        dependency.searchUseCase.storyGuideComplete()
     }
     
 }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/SearchViewController.swift
@@ -62,6 +62,7 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
     private let selectedView = SearchMapSelectedView()
     private let reSearchView = SearchMapReSearchView()
     private let selectedClusterView = SearchMapClusterListView()
+    private let guideView = SearchStoryGuideView()
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -152,6 +153,10 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
         reSearchView.isHidden = true
     }
     
+    func showStoryGuideView() {
+        guideView.showWithAnimation()
+    }
+    
     func deselectAll() {
         hideSelectedMarker()
         selectedView.isHidden = true
@@ -162,7 +167,7 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
     override func setupLayout() {
         view = naverMap
         
-        [searchView, reSearchView, showSearchHomeListButton, storyView, selectedView, selectedClusterView].forEach(view.addSubview)
+        [searchView, reSearchView, showSearchHomeListButton, storyView, selectedView, selectedClusterView, guideView].forEach(view.addSubview)
         
         NSLayoutConstraint.activate([
             searchView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constant.SearchTextField.topSpacing),
@@ -189,6 +194,11 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
             selectedClusterView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.traillingOffset),
             selectedClusterView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
             selectedClusterView.heightAnchor.constraint(equalToConstant: 250),
+            
+            guideView.topAnchor.constraint(equalTo: view.topAnchor),
+            guideView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            guideView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            guideView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
     
@@ -244,6 +254,10 @@ final class SearchViewController: BaseViewController, SearchPresentable, SearchV
         
         selectedClusterView.do {
             $0.isHidden = true
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        guideView.do {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
     }

--- a/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchStoryGuideView.swift
+++ b/client/Targets/Presentation/Search/Implementations/Sources/Search/Views/SearchStoryGuideView.swift
@@ -1,0 +1,87 @@
+//
+//  SearchStoryGuideView.swift
+//  SearchImplementations
+//
+//  Created by 홍성준 on 12/13/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import CoreKit
+import DesignKit
+
+final class SearchStoryGuideView: UIView {
+    
+    private let titleLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        setupAttributes()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupLayout()
+        setupAttributes()
+    }
+    
+    func showWithAnimation() {
+        isUserInteractionEnabled = true
+        
+        UIView.animate(
+            withDuration: 0.3,
+            animations: {
+                self.backgroundColor = .hpBlack.withAlphaComponent(0.4)
+                self.titleLabel.textColor = .hpWhite
+            }
+        )
+    }
+    
+    func hideWithAnimation() {
+        isUserInteractionEnabled = false
+        
+        UIView.animate(
+            withDuration: 0.3,
+            animations: {
+                self.backgroundColor = .clear
+                self.titleLabel.textColor = .clear
+            },
+            completion: { _ in
+                self.isHidden = true
+            }
+        )
+    }
+    
+    private func setupLayout() {
+        addSubview(titleLabel)
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.leadingOffset),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.traillingOffset),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+    
+    private func setupAttributes() {
+        self.do {
+            $0.backgroundColor = .clear
+            $0.addTapGesture(target: self, action: #selector(guideViewDidTap))
+            $0.isUserInteractionEnabled = false
+        }
+        
+        titleLabel.do {
+            $0.text = "지도를 탭하여 스토리를 작성해보세요!"
+            $0.font = .largeSemibold
+            $0.textColor = .clear
+            $0.textAlignment = .center
+            $0.lineBreakStrategy = .hangulWordPriority
+            $0.numberOfLines = 0
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+    
+    @objc private func guideViewDidTap() {
+        hideWithAnimation()
+    }
+    
+}


### PR DESCRIPTION
## 🌁 배경
* close #669 
* 스토리 가이드 노출 여부에 따라 1회 노출됩니다 (UserDefaults 사용)

## ✅ 수정 내역
* 지도 화면에 스토리 생성 가이드 추가

## 🎇 스크린샷
https://github.com/boostcampwm2023/iOS04-HeatPick/assets/74225754/138915a4-381d-4247-8e47-ed3f95c4b970


