### PR TITLE
팔로잉/팔로워 리스트 표시

### DIFF
--- a/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
+++ b/client/Targets/App/Sources/AppRoot/AppRootComponent.swift
@@ -51,7 +51,7 @@ final class AppRootComponent: Component<AppRootDependency>,
     let homeUseCase: HomeUseCaseInterface
     let locationAuthorityUseCase: LocationAuthorityUseCaseInterfaces
     let storyUseCase: StoryUseCaseInterface
-    let myPageUseCase: MyProfileUseCaseInterface
+    let myProfileUseCase: MyProfileUseCaseInterface
     let userProfileUseCase: UserProfileUseCaseInterface
     let searchUseCase: SearchUseCaseInterface
     let followingUseCase: FollowingUseCaseInterface
@@ -122,7 +122,7 @@ final class AppRootComponent: Component<AppRootDependency>,
         self.storyUseCase = StoryUseCase(repository: StoryRepository(session: storyNetworkProvider), locationService: locationService)
         
         let myPageNetworkProvider = AppRootComponent.generateNetworkProvider(isDebug: false, protocols: [MyURLProtocol.self])
-        self.myPageUseCase = MyProfileUseCase(repository: MyProfileRepository(session: myPageNetworkProvider))
+        self.myProfileUseCase = MyProfileUseCase(repository: MyProfileRepository(session: myPageNetworkProvider))
         self.signOutRequestService = SignoutService.shared
         
         self.userProfileUseCase = UserProfileUseCase(repository: UserProfileRepository(session: myPageNetworkProvider))

--- a/client/Targets/Core/FoundationKit/Sources/Alert/AlertType.swift
+++ b/client/Targets/Core/FoundationKit/Sources/Alert/AlertType.swift
@@ -25,6 +25,7 @@ public enum AlertType {
     case didFailToLoadComments
     case didFailToSaveComment
     case didFailToImageLoad
+    case didFailToLoadFollowList
     
 }
 
@@ -47,6 +48,7 @@ extension AlertType {
         case .didFailToLoadComments: return "댓글 정보 획득 실패"
         case .didFailToSaveComment: return "댓글 작성 실패"
         case .didFailToImageLoad: return "이미지 로드 실패"
+        case .didFailToLoadFollowList: return "팔로워/팔로잉 유저 정보 획득 실패"
         }
     }
     
@@ -67,6 +69,7 @@ extension AlertType {
         case .didFailToLoadComments: return "댓글을 불러오는데 실패했어요.\n 확인 버튼을 누르면 이전화면으로 이동해요."
         case .didFailToSaveComment: return "댓글 작성에 실패했어요.\n 다시 시도하시겠어요?"
         case .didFailToImageLoad: return "지원하지 않는 이미지 타입이에요."
+        case .didFailToLoadFollowList: return "팔로워/팔로잉 유저 정보를 가져오는데 실패했어요\n 확인 버튼을 누르면 이전화면으로 이동해요."
         }
     }
     
@@ -87,6 +90,7 @@ extension AlertType {
         case .didFailToLoadComments: return false
         case .didFailToSaveComment: return true
         case .didFailToImageLoad: return false
+        case .didFailToLoadFollowList: return false
         }
     }
     

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkProvider.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/NetworkProvider.swift
@@ -112,7 +112,10 @@ public final class NetworkProvider: Network {
     private func makeRequest(_ target: Target, isMultipartFormData: Bool = false) throws -> NetworkRequest {
         let boundary = UUID().uuidString
         let components: URLComponents? = {
-            let endpoint = target.baseURL.appendingPathComponent(target.path)
+            var endpoint = target.baseURL.appendingPathComponent(target.path)
+            if case let .path(path) = target.task {
+                endpoint.append(path: path)
+            }
             var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: true)
             if case let .url(parameters) = target.task {
                 components?.queryItems = parameters.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
@@ -158,7 +161,7 @@ public final class NetworkProvider: Network {
             return data
         case .json(let encodable):
             return try? encodable.jsonData()
-        case .url:
+        case .url, .path:
             return nil
         case .multipart(let formData):
             return formData.makeData(boundary: boundary)

--- a/client/Targets/Core/Network/NetworkAPIKit/Sources/Task.swift
+++ b/client/Targets/Core/Network/NetworkAPIKit/Sources/Task.swift
@@ -14,6 +14,7 @@ public enum Task {
     case data(Data)
     case json(Encodable)
     case url(parameters: [String: Any])
+    case path(String)
     case multipart(MultipartFormData)
     
 }

--- a/client/Targets/Data/Network/My/Sources/DTO/FollowListResponseDTO.swift
+++ b/client/Targets/Data/Network/My/Sources/DTO/FollowListResponseDTO.swift
@@ -1,0 +1,39 @@
+//
+//  FollowListResponseDTO.swift
+//  MyAPI
+//
+//  Created by jungmin lim on 12/13/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import Foundation
+import DomainEntities
+
+public struct FollowListResponseDTO: Decodable {
+    
+    public let users: [FollowUserResponseDTO]
+    
+    public init(users: [FollowUserResponseDTO]) {
+        self.users = users
+    }
+    
+    public struct FollowUserResponseDTO: Decodable {
+        public let userId: Int
+        public let username: String
+        public let profileUrl: String
+        
+        public init(userId: Int, username: String, profileUrl: String) {
+            self.userId = userId
+            self.username = username
+            self.profileUrl = profileUrl
+        }
+        
+        public func toDomain() -> SearchUser {
+            .init(userId: userId, username: username, profileUrl: profileUrl)
+        }
+    }
+
+    public func toDomain() -> [SearchUser] {
+        users.map { $0.toDomain() }
+    }
+}

--- a/client/Targets/Data/Network/My/Sources/DTO/MyProfileResponseDTO.swift
+++ b/client/Targets/Data/Network/My/Sources/DTO/MyProfileResponseDTO.swift
@@ -23,6 +23,7 @@ public struct MyProfileProfileResponseDTO: Decodable {
     public let profileURL: String?
     public let isFollow: Bool
     public let followerCount: Int
+    public let followingCount:Int
     public let storyCount: Int
     public let experience: Int
     public let maxExperience: Int
@@ -61,6 +62,7 @@ public extension MyProfileResponseDTO {
             temperature: profile.temperature,
             temperatureFeeling: profile.temperatureFeeling,
             followerCount: profile.followerCount,
+            followingCount: profile.followingCount,
             storyCount: profile.storyCount,
             experience: profile.experience,
             maxExperience: profile.maxExperience,

--- a/client/Targets/Data/Network/My/Sources/MyAPI.swift
+++ b/client/Targets/Data/Network/My/Sources/MyAPI.swift
@@ -21,6 +21,10 @@ public enum MyAPI {
     case follow(id: Int)
     case unfollow(id: Int)
     case checkUserName(username: String)
+    case myFollowers
+    case myFollowings
+    case followers(Int)
+    case followings(Int)
 }
 
 extension MyAPI: Target {
@@ -39,6 +43,8 @@ extension MyAPI: Target {
         case .resign: return "/user/resign"
         case .follow, .unfollow: return "/user/follow"
         case .checkUserName: return "/auth/check"
+        case .myFollowers, .followers: return "/user/follower"
+        case .myFollowings, .followings: return "/user/follow"
         }
     }
     
@@ -84,6 +90,11 @@ extension MyAPI: Target {
             
         case let .checkUserName(username):
             return .url(parameters: CheckUserNameReqeustDTO(username: username).parameters())
+            
+        case .myFollowers, .myFollowings:
+            return .plain
+        case .followers(let userId), .followings(let userId):
+            return .path("/\(userId)")
         }
     }
     

--- a/client/Targets/Data/Repositories/Sources/MyProfileRepository.swift
+++ b/client/Targets/Data/Repositories/Sources/MyProfileRepository.swift
@@ -64,4 +64,18 @@ public final class MyProfileRepository: MyProfileRepositoryInterface {
         await session.request(MyAPI.checkUserName(username: username))
     }
 
+    public func requestFollowers() async -> Result<[SearchUser], Error> {
+        let target = MyAPI.myFollowers
+        let request: Result<FollowListResponseDTO, Error> = await session.request(target)
+        
+        return request.map { $0.toDomain() }
+    }
+
+    public func requestFollowings() async -> Result<[SearchUser], Error> {
+        let target = MyAPI.myFollowings
+        let request: Result<FollowListResponseDTO, Error> = await session.request(target)
+        
+        return request.map { $0.toDomain() }
+    }
+    
 }

--- a/client/Targets/Data/Repositories/Sources/UserProfileRepository.swift
+++ b/client/Targets/Data/Repositories/Sources/UserProfileRepository.swift
@@ -43,6 +43,19 @@ public final class UserProfileRepository: UserProfileRepositoryInterface {
         let target = MyAPI.unfollow(id: userId)
         return await session.request(target)
     }
+    
+    public func requestFollowers(userId: Int) async -> Result<[SearchUser], Error> {
+        let target = MyAPI.followers(userId)
+        let request: Result<FollowListResponseDTO, Error> = await session.request(target)
+        
+        return request.map { $0.toDomain() }
+    }
 
+    public func requestFollowings(userId: Int) async -> Result<[SearchUser], Error> {
+        let target = MyAPI.followings(userId)
+        let request: Result<FollowListResponseDTO, Error> = await session.request(target)
+        
+        return request.map { $0.toDomain() }
+    }
 }
 

--- a/client/Targets/Domain/Entities/Sources/My/MyProfile.swift
+++ b/client/Targets/Domain/Entities/Sources/My/MyProfile.swift
@@ -16,6 +16,7 @@ public struct MyProfile {
     public let temperature: Double
     public let temperatureFeeling: String
     public let followerCount: Int
+    public let followingCount: Int
     public let storyCount: Int
     public let experience: Int
     public let maxExperience: Int
@@ -28,6 +29,7 @@ public struct MyProfile {
         self.temperature = profile.temperature
         self.temperatureFeeling = profile.temperatureFeeling
         self.followerCount = profile.followerCount
+        self.followingCount = profile.followingCount
         self.storyCount = profile.storyCount
         self.experience = profile.experience
         self.maxExperience = profile.maxExperience

--- a/client/Targets/Domain/Entities/Sources/My/Profile.swift
+++ b/client/Targets/Domain/Entities/Sources/My/Profile.swift
@@ -17,6 +17,7 @@ public struct Profile {
     public let temperature: Double
     public let temperatureFeeling: String
     public let followerCount: Int
+    public let followingCount: Int
     public let storyCount: Int
     public let experience: Int
     public let maxExperience: Int
@@ -31,6 +32,7 @@ public struct Profile {
         temperature: Double,
         temperatureFeeling: String,
         followerCount: Int,
+        followingCount: Int,
         storyCount: Int,
         experience: Int,
         maxExperience: Int,
@@ -44,6 +46,7 @@ public struct Profile {
         self.temperature = temperature
         self.temperatureFeeling = temperatureFeeling
         self.followerCount = followerCount
+        self.followingCount = followingCount
         self.storyCount = storyCount
         self.experience = experience
         self.maxExperience = maxExperience

--- a/client/Targets/Domain/Entities/Sources/My/UserProfile.swift
+++ b/client/Targets/Domain/Entities/Sources/My/UserProfile.swift
@@ -17,6 +17,7 @@ public struct UserProfile {
     public let temperature: Double
     public let temperatureFeeling: String
     public let followerCount: Int
+    public let followingCount: Int
     public let storyCount: Int
     public let experience: Int
     public let maxExperience: Int
@@ -30,6 +31,7 @@ public struct UserProfile {
         self.temperature = profile.temperature
         self.temperatureFeeling = profile.temperatureFeeling
         self.followerCount = profile.followerCount
+        self.followingCount = profile.followingCount
         self.storyCount = profile.storyCount
         self.experience = profile.experience
         self.maxExperience = profile.maxExperience

--- a/client/Targets/Domain/Interfaces/Sources/Repository/Profile/MyProfileRepositoryInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/Repository/Profile/MyProfileRepositoryInterface.swift
@@ -16,5 +16,7 @@ public protocol MyProfileRepositoryInterface: ProfileRepositoryInterface {
     func patchUserUpdate(userUpdate: UserUpdateContent) async -> Result<Int, Error>
     func requestResign(message: String) async -> Result<Void, Error>
     func checkUsername(username: String) async -> Result<Void, Error>
+    func requestFollowers() async -> Result<[SearchUser], Error>
+    func requestFollowings() async -> Result<[SearchUser], Error>
     
 }

--- a/client/Targets/Domain/Interfaces/Sources/Repository/Profile/UserProfileRepositoryInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/Repository/Profile/UserProfileRepositoryInterface.swift
@@ -12,5 +12,6 @@ import DomainEntities
 public protocol UserProfileRepositoryInterface: ProfileRepositoryInterface {
  
     func fetchUserProfile(userId: Int) async -> Result<Profile, Error>
-    
+    func requestFollowers(userId: Int) async -> Result<[SearchUser], Error>
+    func requestFollowings(userId: Int) async -> Result<[SearchUser], Error>
 }

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Profile/MyProfile/MyProfileUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Profile/MyProfile/MyProfileUseCaseInterface.swift
@@ -15,5 +15,6 @@ public protocol MyProfileUseCaseInterface: ProfileUserDashboardUseCaseInterface,
                                         MyProfileSettingUseCaseInterface {
     
     func fetchMyProfile() async -> Result<Profile, Error>
-    
+    func fetchFollowers() async -> Result<[SearchUser], Error>
+    func fetchFollowings() async -> Result<[SearchUser], Error>
 }

--- a/client/Targets/Domain/Interfaces/Sources/UseCase/Profile/UserProfile/UserProfileUseCaseInterface.swift
+++ b/client/Targets/Domain/Interfaces/Sources/UseCase/Profile/UserProfile/UserProfileUseCaseInterface.swift
@@ -15,4 +15,6 @@ public protocol UserProfileUseCaseInterface: ProfileUserDashboardUseCaseInterfac
                                               ProfileStoryDashboardUseCaseInterface {
     
     func fetchUserProfile(userId: Int) async -> Result<Profile, Error>
+    func fetchFollowers(userId: Int) async -> Result<[SearchUser], Error>
+    func fetchFollowings(userId: Int) async -> Result<[SearchUser], Error>
 }

--- a/client/Targets/Domain/UseCases/Sources/MyProfileUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/MyProfileUseCase.swift
@@ -115,4 +115,11 @@ public final class MyProfileUseCase: MyProfileUseCaseInterface {
         await repository.checkUsername(username: username)
     }
     
+    public func fetchFollowers() async -> Result<[SearchUser], Error> {
+        await repository.requestFollowers()
+    }
+    
+    public func fetchFollowings() async -> Result<[SearchUser], Error> {
+        await repository.requestFollowings()
+    }
 }

--- a/client/Targets/Domain/UseCases/Sources/UserProfileUseCase.swift
+++ b/client/Targets/Domain/UseCases/Sources/UserProfileUseCase.swift
@@ -99,5 +99,12 @@ public final class UserProfileUseCase: UserProfileUseCaseInterface {
         await repository.requestUnfollow(userId: userId)
     }
     
+    public func fetchFollowers(userId: Int) async -> Result<[SearchUser], Error> {
+        await repository.requestFollowers(userId: userId)
+    }
+    
+    public func fetchFollowings(userId: Int) async -> Result<[SearchUser], Error> {
+        await repository.requestFollowings(userId: userId)
+    }
 }
 

--- a/client/Targets/Presentation/BasePresentation/Sources/User/Cells/UserSmallTableViewCell.swift
+++ b/client/Targets/Presentation/BasePresentation/Sources/User/Cells/UserSmallTableViewCell.swift
@@ -83,9 +83,9 @@ private extension UserSmallTableViewCell {
         [profileImageView, nicknameLabel].forEach(contentView.addSubview)
         
         NSLayoutConstraint.activate([
-            profileImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            profileImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constant.spacing),
             profileImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.leadingOffset),
-            profileImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            profileImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Constant.spacing),
             profileImageView.heightAnchor.constraint(equalToConstant: Constant.ProfileImageView.height),
             profileImageView.widthAnchor.constraint(equalToConstant: Constant.ProfileImageView.width),
             

--- a/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListBuilder.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListBuilder.swift
@@ -1,0 +1,59 @@
+//
+//  FollowListBuilder.swift
+//  MyImplementations
+//
+//  Created by jungmin lim on 12/13/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+import DomainInterfaces
+
+enum FollowType: String {
+    case follower = "팔로워"
+    case following = "팔로잉"
+}
+
+protocol FollowListDependency: Dependency {
+    var myProfileUseCase: MyProfileUseCaseInterface { get }
+    var userProfileUseCase: UserProfileUseCaseInterface { get }
+}
+
+final class FollowListComponent: Component<FollowListDependency>,
+                                 FollowListInteractorDependency {
+    var userId: Int?
+    let type: FollowType
+    var myProfileUseCase: MyProfileUseCaseInterface {
+        dependency.myProfileUseCase
+    }
+    var userProfileUseCase: UserProfileUseCaseInterface {
+        dependency.userProfileUseCase
+    }
+    
+    init(dependency: FollowListDependency, type: FollowType, userId: Int?) {
+        self.userId = userId
+        self.type = type
+        super.init(dependency: dependency)
+    }
+}
+
+// MARK: - Builder
+
+protocol FollowListBuildable: Buildable {
+    func build(withListener listener: FollowListListener, type: FollowType, userId: Int?) -> ViewableRouting
+}
+
+final class FollowListBuilder: Builder<FollowListDependency>, FollowListBuildable {
+
+    override init(dependency: FollowListDependency) {
+        super.init(dependency: dependency)
+    }
+
+    func build(withListener listener: FollowListListener, type: FollowType, userId: Int?) -> ViewableRouting {
+        let component = FollowListComponent(dependency: dependency, type: type, userId: userId)
+        let viewController = FollowListViewController()
+        let interactor = FollowListInteractor(presenter: viewController, dependency: component)
+        interactor.listener = listener
+        return FollowListRouter(interactor: interactor, viewController: viewController)
+    }
+}

--- a/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListBuilder.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListBuilder.swift
@@ -8,6 +8,7 @@
 
 import ModernRIBs
 import DomainInterfaces
+import MyInterfaces
 
 enum FollowType: String {
     case follower = "팔로워"
@@ -17,10 +18,14 @@ enum FollowType: String {
 protocol FollowListDependency: Dependency {
     var myProfileUseCase: MyProfileUseCaseInterface { get }
     var userProfileUseCase: UserProfileUseCaseInterface { get }
+    var userProfileBuilder: UserProfileBuildable { get}
 }
 
 final class FollowListComponent: Component<FollowListDependency>,
-                                 FollowListInteractorDependency {
+                                 FollowListInteractorDependency,
+                                 FollowListRouterDependency {
+    
+    
     var userId: Int?
     let type: FollowType
     var myProfileUseCase: MyProfileUseCaseInterface {
@@ -28,6 +33,10 @@ final class FollowListComponent: Component<FollowListDependency>,
     }
     var userProfileUseCase: UserProfileUseCaseInterface {
         dependency.userProfileUseCase
+    }
+    
+    var userProfileBuildable: UserProfileBuildable {
+        dependency.userProfileBuilder
     }
     
     init(dependency: FollowListDependency, type: FollowType, userId: Int?) {
@@ -54,6 +63,6 @@ final class FollowListBuilder: Builder<FollowListDependency>, FollowListBuildabl
         let viewController = FollowListViewController()
         let interactor = FollowListInteractor(presenter: viewController, dependency: component)
         interactor.listener = listener
-        return FollowListRouter(interactor: interactor, viewController: viewController)
+        return FollowListRouter(interactor: interactor, viewController: viewController, dependency: component)
     }
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListInteractor.swift
@@ -14,7 +14,10 @@ import BasePresentation
 import DomainEntities
 import DomainInterfaces
 
-protocol FollowListRouting: ViewableRouting { }
+protocol FollowListRouting: ViewableRouting {
+    func attachProfile(userId: Int)
+    func detachProfile()
+}
 
 protocol FollowListPresentable: Presentable {
     var listener: FollowListPresentableListener? { get set }
@@ -67,6 +70,14 @@ final class FollowListInteractor: PresentableInteractor<FollowListPresentable>,
     
     func backButtonDidTap() {
         listener?.followListBackButtonDidTap()
+    }
+    
+    func didTapUser(userId: Int) {
+        router?.attachProfile(userId: userId)
+    }
+    
+    func detachUserProfile() {
+        router?.detachProfile()
     }
 }
 

--- a/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListInteractor.swift
@@ -1,0 +1,170 @@
+//
+//  FollowListInteractor.swift
+//  MyImplementations
+//
+//  Created by jungmin lim on 12/13/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+import CoreKit
+import FoundationKit
+import BasePresentation
+import DomainEntities
+import DomainInterfaces
+
+protocol FollowListRouting: ViewableRouting { }
+
+protocol FollowListPresentable: Presentable {
+    var listener: FollowListPresentableListener? { get set }
+    func setup(model: [UserSmallTableViewCellModel])
+    func present(type: AlertType, okAction: @escaping (() -> Void))
+}
+
+protocol FollowListInteractorDependency: AnyObject {
+    var userId: Int? { get set }
+    var type: FollowType { get }
+    var myProfileUseCase: MyProfileUseCaseInterface { get }
+    var userProfileUseCase: UserProfileUseCaseInterface { get }
+}
+
+protocol FollowListListener: AnyObject { 
+    func followListBackButtonDidTap()
+}
+
+final class FollowListInteractor: PresentableInteractor<FollowListPresentable>,
+                                  FollowListInteractable,
+                                  FollowListPresentableListener {
+
+    weak var router: FollowListRouting?
+    weak var listener: FollowListListener?
+    
+    private let dependency: FollowListInteractorDependency
+    private let cancelBag = CancelBag()
+    
+    init(presenter: FollowListPresentable,
+         dependency: FollowListInteractorDependency) {
+        self.dependency = dependency
+        super.init(presenter: presenter)
+        presenter.listener = self
+    }
+
+    override func didBecomeActive() {
+        super.didBecomeActive()
+        fetchList()
+    }
+
+    override func willResignActive() {
+        super.willResignActive()
+        dependency.userId = nil
+        cancelBag.cancel()
+    }
+    
+    var title: String {
+        dependency.type.rawValue
+    }
+    
+    func backButtonDidTap() {
+        listener?.followListBackButtonDidTap()
+    }
+}
+
+private extension FollowListInteractor {
+    func fetchList() {
+        if let userId = dependency.userId {
+            switch dependency.type {
+            case .follower:
+                fetchFollowers(of: userId)
+            case .following:
+                fetchFollowings(of: userId)
+            }
+        }
+        else {
+            switch dependency.type {
+            case .follower:
+                fetchMyFollowers()
+            case .following:
+                fetchMyFollowings()
+            }
+        }
+    }
+    
+    func fetchMyFollowers() {
+        Task { [weak self] in
+            guard let self else { return }
+            
+            await dependency.myProfileUseCase
+                .fetchFollowers()
+                .onSuccess(on: .main, with: self) { this, users in
+                    this.presenter.setup(model: users.map { $0.toModel() })
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: "fail to load my follwers with \(error.localizedDescription)", log: .interactor)
+                    this.presenter.present(type: .didFailToLoadFollowList) {
+                        this.listener?.followListBackButtonDidTap()
+                    }
+                }
+        }.store(in: cancelBag)
+    }
+    
+    func fetchMyFollowings() {
+        Task { [weak self] in
+            guard let self else { return }
+            
+            await dependency.myProfileUseCase
+                .fetchFollowings()
+                .onSuccess(on: .main, with: self) { this, users in
+                    this.presenter.setup(model: users.map { $0.toModel() })
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: "fail to load my follwers with \(error.localizedDescription)", log: .interactor)
+                    this.presenter.present(type: .didFailToLoadFollowList) {
+                        this.listener?.followListBackButtonDidTap()
+                    }
+                }
+        }.store(in: cancelBag)
+    }
+    
+    func fetchFollowers(of userId: Int) {
+        Task { [weak self] in
+            guard let self else { return }
+            
+            await dependency.userProfileUseCase
+                .fetchFollowers(userId: userId)
+                .onSuccess(on: .main, with: self) { this, users in
+                    this.presenter.setup(model: users.map { $0.toModel() })
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: "fail to load my follwers with \(error.localizedDescription)", log: .interactor)
+                    this.presenter.present(type: .didFailToLoadFollowList) {
+                        this.listener?.followListBackButtonDidTap()
+                    }
+                }
+        }.store(in: cancelBag)
+    }
+    
+    func fetchFollowings(of userId: Int) {
+        Task { [weak self] in
+            guard let self else { return }
+            
+            await dependency.userProfileUseCase
+                .fetchFollowings(userId: userId)
+                .onSuccess(on: .main, with: self) { this, users in
+                    this.presenter.setup(model: users.map { $0.toModel() })
+                }
+                .onFailure(on: .main, with: self) { this, error in
+                    Log.make(message: "fail to load my follwers with \(error.localizedDescription)", log: .interactor)
+                    this.presenter.present(type: .didFailToLoadFollowList) {
+                        this.listener?.followListBackButtonDidTap()
+                    }
+                }
+        }.store(in: cancelBag)
+    }
+}
+
+fileprivate extension SearchUser {
+    func toModel() -> UserSmallTableViewCellModel {
+        .init(userId: userId, username: username, profileUrl: profileUrl)
+    }
+}

--- a/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListRouter.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListRouter.swift
@@ -1,0 +1,27 @@
+//
+//  FollowListRouter.swift
+//  MyImplementations
+//
+//  Created by jungmin lim on 12/13/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import ModernRIBs
+
+protocol FollowListInteractable: Interactable {
+    var router: FollowListRouting? { get set }
+    var listener: FollowListListener? { get set }
+}
+
+protocol FollowListViewControllable: ViewControllable {
+    // TODO: Declare methods the router invokes to manipulate the view hierarchy.
+}
+
+final class FollowListRouter: ViewableRouter<FollowListInteractable, FollowListViewControllable>, FollowListRouting {
+
+    // TODO: Constructor inject child builder protocols to allow building children.
+    override init(interactor: FollowListInteractable, viewController: FollowListViewControllable) {
+        super.init(interactor: interactor, viewController: viewController)
+        interactor.router = self
+    }
+}

--- a/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListViewController.swift
@@ -15,6 +15,7 @@ import BasePresentation
 protocol FollowListPresentableListener: AnyObject {
     var title: String { get }
     func backButtonDidTap()
+    func didTapUser(userId: Int)
 }
 
 final class FollowListViewController: BaseViewController,
@@ -76,7 +77,9 @@ extension FollowListViewController: NavigationViewDelegate {
 }
 
 extension FollowListViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let model = users[safe: indexPath.row] else { return }
+        listener?.didTapUser(userId: model.userId)
     }
 }
 

--- a/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListViewController.swift
@@ -44,6 +44,8 @@ final class FollowListViewController: BaseViewController,
     }
     
     override func setupAttributes() {
+        view.backgroundColor = .hpWhite
+        
         navigationView.do {
             $0.setup(model: .init(title: listener?.title ?? "",
                                   leftButtonType: .back,

--- a/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/FollowList/FollowListViewController.swift
@@ -1,0 +1,96 @@
+//
+//  FollowListViewController.swift
+//  MyImplementations
+//
+//  Created by jungmin lim on 12/13/23.
+//  Copyright © 2023 codesquad. All rights reserved.
+//
+
+import UIKit
+import ModernRIBs
+
+import DesignKit
+import BasePresentation
+
+protocol FollowListPresentableListener: AnyObject {
+    var title: String { get }
+    func backButtonDidTap()
+}
+
+final class FollowListViewController: BaseViewController,
+                                      FollowListPresentable,
+                                      FollowListViewControllable {
+
+    weak var listener: FollowListPresentableListener?
+    
+    private var users: [UserSmallTableViewCellModel] = []
+    private let tableView = UITableView(frame: .zero, style: .grouped)
+    
+    override func setupLayout() {
+        [navigationView, tableView].forEach(view.addSubview)
+        
+        NSLayoutConstraint.activate([
+            navigationView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            navigationView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            navigationView.heightAnchor.constraint(equalToConstant: Constants.navigationViewHeight),
+            
+            tableView.topAnchor.constraint(equalTo: navigationView.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    override func setupAttributes() {
+        navigationView.do {
+            $0.setup(model: .init(title: listener?.title ?? "",
+                                  leftButtonType: .back,
+                                  rightButtonTypes: [.none]))
+            $0.delegate = self
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        tableView.do {
+            $0.backgroundColor = .hpWhite
+            $0.register(UserSmallTableViewCell.self)
+            $0.delegate = self
+            $0.dataSource = self
+            $0.contentInset = .zero
+            $0.separatorStyle = .none
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+    
+    func setup(model: [UserSmallTableViewCellModel]) {
+        self.users = model
+        tableView.reloadData()
+    }
+}
+
+
+extension FollowListViewController: NavigationViewDelegate {
+    func navigationViewButtonDidTap(_ view: NavigationView, type: NavigationViewButtonType) {
+        listener?.backButtonDidTap()
+    }
+}
+
+extension FollowListViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    }
+}
+
+extension FollowListViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        users.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let model = users[safe: indexPath.row] else { return .init() }
+        
+        let cell = tableView.dequeue(UserSmallTableViewCell.self, for: indexPath)
+        cell.setup(model: model)
+        
+        return cell
+    }
+}

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageDependency.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageDependency.swift
@@ -15,7 +15,8 @@ import DomainInterfaces
 // MARK: Builder
 public protocol MyPageDependency: Dependency {
     
-    var myPageUseCase: MyProfileUseCaseInterface { get }
+    var myProfileUseCase: MyProfileUseCaseInterface { get }
+    var userProfileUseCase: UserProfileUseCaseInterface { get }
     var signOutRequestService: SignOutRequestServiceInterface { get }
     var storyDetailBuilder: StoryDetailBuildable { get }
     var locationAuthorityUseCase: LocationAuthorityUseCaseInterfaces { get }
@@ -29,13 +30,15 @@ final class MyPageComponent: Component<MyPageDependency>,
                              ProfileStoryDashboardSeeAllDependency,
                              MyPageInteractorDependency,
                              SettingDependency,
-                             MyProfileUpdateUserDashboardDependency {
+                             MyProfileUpdateUserDashboardDependency,
+                             FollowListDependency {
     
-    var myPageUseCase: MyProfileUseCaseInterface { dependency.myPageUseCase }
-    var profileUserDashboardUseCaseInterface: ProfileUserDashboardUseCaseInterface { dependency.myPageUseCase }
-    var profileStoryDashboardUseCase: ProfileStoryDashboardUseCaseInterface { dependency.myPageUseCase }
-    var myPageUpdateUserUseCase: MyProfileUpdateUserUseCaseInterface { dependency.myPageUseCase }
-    var myProfileSettingUseCase: MyProfileSettingUseCaseInterface { dependency.myPageUseCase }
+    var myProfileUseCase: MyProfileUseCaseInterface { dependency.myProfileUseCase }
+    var userProfileUseCase: UserProfileUseCaseInterface { dependency.userProfileUseCase }
+    var profileUserDashboardUseCaseInterface: ProfileUserDashboardUseCaseInterface { dependency.myProfileUseCase }
+    var profileStoryDashboardUseCase: ProfileStoryDashboardUseCaseInterface { dependency.myProfileUseCase }
+    var myPageUpdateUserUseCase: MyProfileUpdateUserUseCaseInterface { dependency.myProfileUseCase }
+    var myProfileSettingUseCase: MyProfileSettingUseCaseInterface { dependency.myProfileUseCase }
     var signOutRequestService: SignOutRequestServiceInterface { dependency.signOutRequestService }
     var storyDetailBuilder: StoryDetailBuildable { dependency.storyDetailBuilder }
     var locationAuthorityUseCase: LocationAuthorityUseCaseInterfaces { dependency.locationAuthorityUseCase }
@@ -57,6 +60,7 @@ protocol MypageRouterDependency: AnyObject {
     var settingBuilder: SettingBuildable { get }
     var storyDetailBuilder: StoryDetailBuildable { get }
     var updateUserDashboardBuilder: MyProfileUpdateUserDashboardBuildable { get }
+    var followListBuilder: FollowListBuildable { get }
     
 }
 
@@ -68,6 +72,7 @@ final class MyPageRouterComponent: MypageRouterDependency {
     let settingBuilder: SettingBuildable
     let storyDetailBuilder: StoryDetailBuildable
     let updateUserDashboardBuilder: MyProfileUpdateUserDashboardBuildable
+    let followListBuilder: FollowListBuildable
     
     init(component: MyPageComponent) {
         self.userDashboardBuilder = MyPageUserDashboardBuilder(dependency: component)
@@ -76,6 +81,7 @@ final class MyPageRouterComponent: MypageRouterDependency {
         self.settingBuilder = SettingBuilder(dependency: component)
         self.storyDetailBuilder = component.storyDetailBuilder
         self.updateUserDashboardBuilder = MyProfileUpdateUserDashboardBuilder(dependency: component)
+        self.followListBuilder = FollowListBuilder(dependency: component)
     }
     
 }
@@ -83,5 +89,5 @@ final class MyPageRouterComponent: MypageRouterDependency {
 
 // MARK: Interactor
 protocol MyPageInteractorDependency: AnyObject {
-    var myPageUseCase: MyProfileUseCaseInterface { get }
+    var myProfileUseCase: MyProfileUseCaseInterface { get }
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageDependency.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageDependency.swift
@@ -21,6 +21,7 @@ public protocol MyPageDependency: Dependency {
     var storyDetailBuilder: StoryDetailBuildable { get }
     var locationAuthorityUseCase: LocationAuthorityUseCaseInterfaces { get }
     var notificationPermissionUseCase: NotificationPermissionUseCaseInterface { get }
+    var userProfileBuilder: UserProfileBuildable { get }
     
 }
 
@@ -33,6 +34,7 @@ final class MyPageComponent: Component<MyPageDependency>,
                              MyProfileUpdateUserDashboardDependency,
                              FollowListDependency {
     
+    
     var myProfileUseCase: MyProfileUseCaseInterface { dependency.myProfileUseCase }
     var userProfileUseCase: UserProfileUseCaseInterface { dependency.userProfileUseCase }
     var profileUserDashboardUseCaseInterface: ProfileUserDashboardUseCaseInterface { dependency.myProfileUseCase }
@@ -43,6 +45,7 @@ final class MyPageComponent: Component<MyPageDependency>,
     var storyDetailBuilder: StoryDetailBuildable { dependency.storyDetailBuilder }
     var locationAuthorityUseCase: LocationAuthorityUseCaseInterfaces { dependency.locationAuthorityUseCase }
     var notificationPermissionUseCase: NotificationPermissionUseCaseInterface { dependency.notificationPermissionUseCase }
+    var userProfileBuilder: UserProfileBuildable { dependency.userProfileBuilder }
     
     override init(dependency: MyPageDependency) {
         super.init(dependency: dependency)

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageInteractor.swift
@@ -26,6 +26,10 @@ protocol MyPageRouting: ViewableRouting {
     func detachSetting()
     func attachupdateUserDashboard()
     func detachUpdateUserDashboard()
+    func attachFollowerList()
+    func detachFollowerList()
+    func attachFollowingList()
+    func detachFollowingList()
 }
 
 protocol MyPagePresentable: Presentable {
@@ -81,6 +85,14 @@ final class MyPageInteractor: PresentableInteractor<MyPagePresentable>, MyPageIn
     
     func detachMyPageUpdateUserDasbaord() {
         router?.detachUpdateUserDashboard()
+    }
+    
+    func followerDidTap() {
+        router?.attachFollowerList()
+    }
+    
+    func followingDidTap() {
+        router?.attachFollowingList()
     }
     
     // MARK: - StoryDashboard

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageInteractor.swift
@@ -27,9 +27,8 @@ protocol MyPageRouting: ViewableRouting {
     func attachupdateUserDashboard()
     func detachUpdateUserDashboard()
     func attachFollowerList()
-    func detachFollowerList()
     func attachFollowingList()
-    func detachFollowingList()
+    func detachFollowList()
 }
 
 protocol MyPagePresentable: Presentable {
@@ -95,6 +94,10 @@ final class MyPageInteractor: PresentableInteractor<MyPagePresentable>, MyPageIn
         router?.attachFollowingList()
     }
     
+    func followListBackButtonDidTap() {
+        router?.detachFollowList()
+    }
+    
     // MARK: - StoryDashboard
     func profileStoryDashboardDidTapSeeAll() {
         guard let profile else { return }
@@ -124,7 +127,7 @@ final class MyPageInteractor: PresentableInteractor<MyPagePresentable>, MyPageIn
     private func fetchProfile() {
         Task { [weak self] in
             guard let self else { return }
-            await dependency.myPageUseCase
+            await dependency.myProfileUseCase
                 .fetchMyProfile()
                 .onSuccess(on: .main, with: self) { this, profile in
                     this.profile = profile

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageRouter.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageRouter.swift
@@ -16,7 +16,8 @@ protocol MyPageInteractable: Interactable,
                              ProfileStoryDashboardSeeAllListener,
                              SettingListener,
                              StoryDetailListener,
-                             MyProfileUpdateUserDashboardListener { 
+                             MyProfileUpdateUserDashboardListener,
+                             FollowListListener {
     var router: MyPageRouting? { get set }
     var listener: MyPageListener? { get set }
 }
@@ -34,6 +35,7 @@ final class MyPageRouter: ViewableRouter<MyPageInteractable, MyPageViewControlla
     private var settingRouting: ViewableRouting?
     private var storyDetailRouting: ViewableRouting?
     private var updateUserDashoardRouting: ViewableRouting?
+    private var followListRouting: ViewableRouting?
     
     private let dependency: MypageRouterDependency
     
@@ -133,19 +135,23 @@ final class MyPageRouter: ViewableRouter<MyPageInteractable, MyPageViewControlla
     }
     
     func attachFollowerList() {
-        
-    }
-    
-    func detachFollowerList() {
-        
+        guard followListRouting == nil else { return }
+        let router = dependency.followListBuilder.build(withListener: interactor, type: .follower, userId: nil)
+        pushRouter(router, animated: true)
+        self.followListRouting = router
     }
     
     func attachFollowingList() {
-        
+        guard followListRouting == nil else { return }
+        let router = dependency.followListBuilder.build(withListener: interactor, type: .following, userId: nil)
+        pushRouter(router, animated: true)
+        self.followListRouting = router
     }
     
-    func detachFollowingList() {
-        
+    func detachFollowList() {
+        guard let router = followListRouting else { return }
+        popRouter(router, animated: true)
+        self.followListRouting = nil
     }
     
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageRouter.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageRouter.swift
@@ -132,4 +132,20 @@ final class MyPageRouter: ViewableRouter<MyPageInteractable, MyPageViewControlla
         updateUserDashoardRouting = nil
     }
     
+    func attachFollowerList() {
+        
+    }
+    
+    func detachFollowerList() {
+        
+    }
+    
+    func attachFollowingList() {
+        
+    }
+    
+    func detachFollowingList() {
+        
+    }
+    
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/MyPageViewController.swift
@@ -22,7 +22,7 @@ public final class MyPageViewController: BaseViewController, MyPagePresentable, 
     weak var listener: MyPagePresentableListener?
 
     private enum Constant {
-        static let tabBarTitle = "마이"
+        static let tabBarTitle = "프로필"
         static let tabBarImage = "person"
         static let tabBarImageSelected = "person.fill"
         static let contentInset: UIEdgeInsets = .init(top: 20, left: 0, bottom: 20, right: 0)

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UserDashboard/MyPageUserDashboardInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UserDashboard/MyPageUserDashboardInteractor.swift
@@ -21,6 +21,8 @@ protocol MyPageUserDashboardPresentable: Presentable {
 
 protocol MyPageUserDashboardListener: AnyObject {
     func profileEditButtonDidTap()
+    func followerDidTap()
+    func followingDidTap()
 }
 
 protocol MyPageUserDashboardInteractorDependency: AnyObject {
@@ -63,6 +65,14 @@ final class MyPageUserDashboardInteractor: PresentableInteractor<MyPageUserDashb
         listener?.profileEditButtonDidTap()
     }
     
+    func followerDidTap() {
+        listener?.followerDidTap()
+    }
+    
+    func followingDidTap() {
+        listener?.followingDidTap()
+    }
+    
 }
 
 private extension MyProfile {
@@ -72,6 +82,7 @@ private extension MyProfile {
             userName: userName,
             profileImageURL: profileImageURL,
             follower: "\(followerCount)", // 팔로잉 변환 로직 추가
+            following: "\(followingCount)",
             storyCount: "\(storyCount)",
             experience: "\((experience * 100) / maxExperience)%",
             temperatureTitle: temperatureFeeling,

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UserDashboard/MyPageUserDashboardViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UserDashboard/MyPageUserDashboardViewController.swift
@@ -12,12 +12,15 @@ import DesignKit
 
 protocol MyPageUserDashboardPresentableListener: AnyObject {
     func profileEditButtonDidTap()
+    func followerDidTap()
+    func followingDidTap()
 }
 
 struct MyProfileViewControllerModel {
     let userName: String
     let profileImageURL: String?
     let follower: String
+    let following: String
     let storyCount: String
     let experience: String
     let temperatureTitle: String
@@ -61,6 +64,7 @@ final class MyPageUserDashboardViewController: UIViewController, MyPageUserDashb
         userView.setup(model: .init(
             profileImageURL: model.profileImageURL,
             follower: model.follower,
+            following: model.following,
             isFollow: false,
             story: model.storyCount,
             experience: model.experience
@@ -76,6 +80,14 @@ extension MyPageUserDashboardViewController: MyPageUserViewDelegate {
     
     func profileEditButtonDidTap() {
         listener?.profileEditButtonDidTap()
+    }
+    
+    func followerDidTap() {
+        listener?.followerDidTap()
+    }
+    
+    func followingDidTap() {
+        listener?.followingDidTap()
     }
     
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UserDashboard/Views/MyProfileUserView.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/MyProfile/UserDashboard/Views/MyProfileUserView.swift
@@ -12,11 +12,14 @@ import DesignKit
 
 protocol MyPageUserViewDelegate: AnyObject {
     func profileEditButtonDidTap()
+    func followerDidTap()
+    func followingDidTap()
 }
 
 struct MyPageUserViewModel {
     let profileImageURL: String?
     let follower: String
+    let following: String
     let isFollow: Bool
     let story: String
     let experience: String
@@ -79,9 +82,17 @@ final class MyProfileUserView: UIView {
         return button
     }()
     
-    private let followerView: ProfileUserContnetView = {
+    private lazy var followerView: ProfileUserContnetView = {
         let view = ProfileUserContnetView()
         view.updateTitle("😀 팔로워")
+        view.addTapGesture(target: self, action: #selector(followerDidTap))
+        return view
+    }()
+    
+    private lazy var followingView: ProfileUserContnetView = {
+        let view = ProfileUserContnetView()
+        view.updateTitle("😀 팔로잉")
+        view.addTapGesture(target: self, action: #selector(followingDidTap))
         return view
     }()
     
@@ -108,6 +119,7 @@ final class MyProfileUserView: UIView {
         } else { profileImageView.image = .profileDefault }
         
         followerView.updateContent(model.follower)
+        followingView.updateContent(model.following)
         storyView.updateContent(model.story)
     }
     
@@ -119,13 +131,21 @@ private extension MyProfileUserView {
         delegate?.profileEditButtonDidTap()
     }
     
+    @objc func followerDidTap(){
+        delegate?.followerDidTap()
+    }
+    
+    @objc func followingDidTap() {
+        delegate?.followingDidTap()
+    }
+    
 }
 
 private extension MyProfileUserView {
     
     func setupViews() {
         [profileImageView, containerContentStackView].forEach(addSubview)
-        [followerView, storyView].forEach(contentStackView.addArrangedSubview)
+        [followerView, followingView, storyView].forEach(contentStackView.addArrangedSubview)
         [contentStackView, profileEditButton].forEach(containerContentStackView.addArrangedSubview)
         
         NSLayoutConstraint.activate([

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserDashboard/UserProfileUserDashboardInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserDashboard/UserProfileUserDashboardInteractor.swift
@@ -26,6 +26,8 @@ protocol UserProfileUserDashboardPresentable: Presentable {
 
 protocol UserProfileUserDashboardListener: AnyObject  {
     func fetchProfile()
+    func followerDidTap()
+    func followingDidTap()
 }
 
 protocol UserProfileUserDashboardInteractorDependency: AnyObject {
@@ -76,6 +78,14 @@ final class UserProfileUserDashboardInteractor: PresentableInteractor<UserProfil
         isFollow ? unfollow() : follow()
     }
     
+    func followerDidTap() {
+        listener?.followerDidTap()
+    }
+    
+    func followingDidTap() {
+        listener?.followingDidTap()
+    }
+    
 }
 
 private extension UserProfileUserDashboardInteractor {
@@ -124,6 +134,7 @@ private extension UserProfile {
             profileImageURL: profileImageURL,
             isFollow: isFollow,
             follower: "\(followerCount)",
+            following: "\(followingCount)",
             storyCount: "\(storyCount)",
             experience: "\((experience * 100) / maxExperience)%",
             temperatureTitle: temperatureFeeling,

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserDashboard/UserProfileUserDashboardViewController.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserDashboard/UserProfileUserDashboardViewController.swift
@@ -12,6 +12,8 @@ import DesignKit
 
 protocol UserProfileUserDashboardPresentableListener: AnyObject {
     func followButtonDidTap()
+    func followerDidTap()
+    func followingDidTap()
 }
 
 struct UserProfileViewControllerModel {
@@ -19,6 +21,7 @@ struct UserProfileViewControllerModel {
     let profileImageURL: String?
     let isFollow: Bool
     let follower: String
+    let following: String
     let storyCount: String
     let experience: String
     let temperatureTitle: String
@@ -63,6 +66,7 @@ final class UserProfileUserDashboardViewController: UIViewController, UserProfil
         userView.setup(model: .init(
             profileImageURL: model.profileImageURL,
             follower: model.follower,
+            following: model.following,
             isFollow: model.isFollow,
             story: model.storyCount,
             experience: model.experience
@@ -81,6 +85,14 @@ extension UserProfileUserDashboardViewController: UserProfileUserViewDelegate {
     
     func followButtonDidTap() {
         listener?.followButtonDidTap()
+    }
+    
+    func followerDidTap() {
+        listener?.followerDidTap()
+    }
+    
+    func followingDidTap() {
+        listener?.followingDidTap()
     }
     
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserDashboard/Views/UserProfileUserView.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserDashboard/Views/UserProfileUserView.swift
@@ -12,11 +12,14 @@ import DesignKit
 
 protocol UserProfileUserViewDelegate: AnyObject {
     func followButtonDidTap()
+    func followerDidTap()
+    func followingDidTap()
 }
 
 struct UserProfileUserViewModel {
     let profileImageURL: String?
     let follower: String
+    let following: String
     let isFollow: Bool
     let story: String
     let experience: String
@@ -81,9 +84,17 @@ final class UserProfileUserView: UIView {
         return button
     }()
     
-    private let followerView: ProfileUserContnetView = {
+    private lazy var followerView: ProfileUserContnetView = {
         let view = ProfileUserContnetView()
         view.updateTitle("😀 팔로워")
+        view.addTapGesture(target: self, action: #selector(followerDidTap))
+        return view
+    }()
+    
+    private lazy var followingView: ProfileUserContnetView = {
+        let view = ProfileUserContnetView()
+        view.updateTitle("😀 팔로잉")
+        view.addTapGesture(target: self, action: #selector(followingDidTap))
         return view
     }()
     
@@ -103,7 +114,7 @@ final class UserProfileUserView: UIView {
         setupViews()
     }
     
-    func setup(model: MyPageUserViewModel) {
+    func setup(model: UserProfileUserViewModel) {
         if let profileImageURL = model.profileImageURL,
            !profileImageURL.isEmpty {
             profileImageView.load(from: model.profileImageURL)
@@ -111,6 +122,7 @@ final class UserProfileUserView: UIView {
         
         updateFollowButton(model.isFollow)
         followerView.updateContent(model.follower)
+        followingView.updateContent(model.following)
         storyView.updateContent(model.story)
     }
     
@@ -127,6 +139,15 @@ private extension UserProfileUserView {
         delegate?.followButtonDidTap()
         followButton.startLoading()
     }
+    
+    @objc func followerDidTap(){
+        delegate?.followerDidTap()
+    }
+    
+    @objc func followingDidTap() {
+        delegate?.followingDidTap()
+    }
+
 }
 
 private extension UserProfileUserView {
@@ -134,7 +155,7 @@ private extension UserProfileUserView {
     func setupViews() {
         [profileStackView, contentStackView].forEach(addSubview)
         [profileImageView, followButton].forEach(profileStackView.addArrangedSubview)
-        [followerView, storyView].forEach(contentStackView.addArrangedSubview)
+        [followerView, followingView, storyView].forEach(contentStackView.addArrangedSubview)
         
         NSLayoutConstraint.activate([
             profileImageView.widthAnchor.constraint(equalToConstant: Constant.profileImageViewWidth),

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileDependency.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileDependency.swift
@@ -14,22 +14,25 @@ import DomainInterfaces
 
 public protocol UserProfileDependency: Dependency {
     var userProfileUseCase: UserProfileUseCaseInterface { get }
+    var myProfileUseCase: MyProfileUseCaseInterface { get }
     var storyDetailBuilder: StoryDetailBuildable { get }
 }
 
 public final class UserProfileComponent: Component<UserProfileDependency>,
-                                  UserProfileInteractorDependency,
-                                  UserProfileUserDashboardDependency,
-                                  ProfileStoryDashboardDependency,
-                                  ProfileStoryDashboardSeeAllDependency {
+                                         UserProfileInteractorDependency,
+                                         UserProfileUserDashboardDependency,
+                                         ProfileStoryDashboardDependency,
+                                         ProfileStoryDashboardSeeAllDependency, 
+                                         FollowListDependency {
     
     var userId: Int
 
     var userProfileUseCase: UserProfileUseCaseInterface { dependency.userProfileUseCase }
+    var myProfileUseCase: MyProfileUseCaseInterface { dependency.myProfileUseCase }
     var profileUserDashboardUseCaseInterface: ProfileUserDashboardUseCaseInterface { dependency.userProfileUseCase }
     var profileStoryDashboardUseCase: ProfileStoryDashboardUseCaseInterface { dependency.userProfileUseCase }
     var storyDetailBuilder: StoryDetailBuildable { dependency.storyDetailBuilder }
-    
+
     init(dependency: UserProfileDependency, userId: Int) {
         self.userId = userId
         super.init(dependency: dependency)
@@ -43,6 +46,7 @@ protocol UserProfileRouterDependency: AnyObject {
     var storyDashboardBuilder: ProfileStoryDashboardBuildable { get }
     var storySeeAllBuilder: ProfileStoryDashboardSeeAllBuildable { get }
     var storyDetailBuilder: StoryDetailBuildable { get }
+    var followListBuilder: FollowListBuildable { get }
     
 }
 
@@ -52,11 +56,13 @@ final class UserProfileRouterComponent: UserProfileRouterDependency {
     let storyDashboardBuilder: ProfileStoryDashboardBuildable
     let storySeeAllBuilder: ProfileStoryDashboardSeeAllBuildable
     let storyDetailBuilder: StoryDetailBuildable
+    let followListBuilder: FollowListBuildable
     
     init(component: UserProfileComponent) {
         self.userDashboardBuilder = UserProfileUserDashboardBuilder(dependency: component)
         self.storyDashboardBuilder = ProfileStoryDashboardBuilder(dependency: component)
         self.storySeeAllBuilder = ProfileStoryDashboardSeeAllBuilder(dependency: component)
+        self.followListBuilder = FollowListBuilder(dependency: component)
         self.storyDetailBuilder = component.storyDetailBuilder
     }
     

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileDependency.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileDependency.swift
@@ -16,6 +16,7 @@ public protocol UserProfileDependency: Dependency {
     var userProfileUseCase: UserProfileUseCaseInterface { get }
     var myProfileUseCase: MyProfileUseCaseInterface { get }
     var storyDetailBuilder: StoryDetailBuildable { get }
+    var userProfileBuilder: UserProfileBuildable { get }
 }
 
 public final class UserProfileComponent: Component<UserProfileDependency>,
@@ -23,7 +24,7 @@ public final class UserProfileComponent: Component<UserProfileDependency>,
                                          UserProfileUserDashboardDependency,
                                          ProfileStoryDashboardDependency,
                                          ProfileStoryDashboardSeeAllDependency, 
-                                         FollowListDependency {
+                                            FollowListDependency {
     
     var userId: Int
 
@@ -32,6 +33,7 @@ public final class UserProfileComponent: Component<UserProfileDependency>,
     var profileUserDashboardUseCaseInterface: ProfileUserDashboardUseCaseInterface { dependency.userProfileUseCase }
     var profileStoryDashboardUseCase: ProfileStoryDashboardUseCaseInterface { dependency.userProfileUseCase }
     var storyDetailBuilder: StoryDetailBuildable { dependency.storyDetailBuilder }
+    var userProfileBuilder: UserProfileBuildable { dependency.userProfileBuilder }
 
     init(dependency: UserProfileDependency, userId: Int) {
         self.userId = userId

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileInteractor.swift
@@ -22,6 +22,10 @@ protocol UserProfileRouting: ViewableRouting {
     func detachStorySeeAll()
     func attachStoryDetail(storyId: Int)
     func detachStoryDetail()
+    func attachFollowerList(userId: Int)
+    func detachFollowerList()
+    func attachFollowingList(userId: Int)
+    func detachFollowingList()
 }
 
 protocol UserProfilePresentable: Presentable {
@@ -102,6 +106,14 @@ final class UserProfileInteractor: PresentableInteractor<UserProfilePresentable>
                     Log.make(message: error.localizedDescription, log: .interactor)
                 }
         }.store(in: cancelBag)
+    }
+    
+    func followerDidTap() {
+        router?.attachFollowerList(userId: dependency.userId)
+    }
+    
+    func followingDidTap() {
+        router?.attachFollowingList(userId: dependency.userId)
     }
 
     func storyDetailDidTapClose() {

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileInteractor.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileInteractor.swift
@@ -23,9 +23,8 @@ protocol UserProfileRouting: ViewableRouting {
     func attachStoryDetail(storyId: Int)
     func detachStoryDetail()
     func attachFollowerList(userId: Int)
-    func detachFollowerList()
     func attachFollowingList(userId: Int)
-    func detachFollowingList()
+    func detachFollowList()
 }
 
 protocol UserProfilePresentable: Presentable {
@@ -114,6 +113,10 @@ final class UserProfileInteractor: PresentableInteractor<UserProfilePresentable>
     
     func followingDidTap() {
         router?.attachFollowingList(userId: dependency.userId)
+    }
+    
+    func followListBackButtonDidTap() {
+        router?.detachFollowList()
     }
 
     func storyDetailDidTapClose() {

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileRouter.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileRouter.swift
@@ -100,4 +100,20 @@ final class UserProfileRouter: ViewableRouter<UserProfileInteractable, UserProfi
         self.storyDetailRouting = nil
     }
     
+    func attachFollowerList(userId: Int) {
+        
+    }
+    
+    func detachFollowerList() {
+        
+    }
+    
+    func attachFollowingList(userId: Int) {
+        
+    }
+    
+    func detachFollowingList() {
+        
+    }
+    
 }

--- a/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileRouter.swift
+++ b/client/Targets/Presentation/My/Implementations/Sources/UserProfile/UserProfileRouter.swift
@@ -14,7 +14,8 @@ protocol UserProfileInteractable: Interactable,
                                   UserProfileUserDashboardListener,
                                   ProfileStoryDashboardListener,
                                   ProfileStoryDashboardSeeAllListener,
-                                  StoryDetailListener {
+                                  StoryDetailListener,
+                                  FollowListListener {
     var router: UserProfileRouting? { get set }
     var listener: UserProfileListener? { get set }
 }
@@ -30,6 +31,7 @@ final class UserProfileRouter: ViewableRouter<UserProfileInteractable, UserProfi
     private var storyDashboardRouting: ProfileStoryDashboardRouting?
     private var storySeeAllRouting: ViewableRouting?
     private var storyDetailRouting: ViewableRouting?
+    private var followListRouting: ViewableRouting?
     
     private let dependency: UserProfileRouterDependency
     
@@ -101,19 +103,23 @@ final class UserProfileRouter: ViewableRouter<UserProfileInteractable, UserProfi
     }
     
     func attachFollowerList(userId: Int) {
-        
-    }
-    
-    func detachFollowerList() {
-        
+        guard followListRouting == nil else { return }
+        let router = dependency.followListBuilder.build(withListener: interactor, type: .follower, userId: userId)
+        pushRouter(router, animated: true)
+        self.followListRouting = router
     }
     
     func attachFollowingList(userId: Int) {
-        
+        guard followListRouting == nil else { return }
+        let router = dependency.followListBuilder.build(withListener: interactor, type: .following, userId: userId)
+        pushRouter(router, animated: true)
+        self.followListRouting = router
     }
     
-    func detachFollowingList() {
-        
+    func detachFollowList() {
+        guard let router = followListRouting else { return }
+        popRouter(router, animated: true)
+        self.followListRouting = nil
     }
     
 }


### PR DESCRIPTION
## 🌁 배경
* #670

## ✅ 수정 내역
* follow list 리블렛 추가
* 마이 페이지 / 유저 프로필 페이지에서 팔로워 팔로잉 리스트를 볼 수 있도록 추가

## 📕 리뷰 노트
* 메모리를 너무 많이 씁니다.
  * view가 위에 계속 붙으면서 밑에 있는 이미지에 대한 메모리가 해제되지 않아 생기는 문제입니다.
  * 기본적으로 메모리를 많이 사용하는 문제가 있어 근본적으로 해결을 위해서는 이미지를 최적화 하는 방법이 필요합니다.

* user/follow/{id} API가 저희 Network API 사양으로는 만들지 못하는 uri라 Target에 `path(String)`을 추가했습니다.

## 🎇 스크린샷
*
![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-12-14 at 10 04 13](https://github.com/boostcampwm2023/iOS04-HeatPick/assets/32038936/34675576-d09b-4f28-b3b9-910ae1cd0b99)

