### PR TITLE
스토리 생성 시 경험치 제공량 변경

### DIFF
--- a/server/src/story/story.service.ts
+++ b/server/src/story/story.service.ts
@@ -101,7 +101,7 @@ export class StoryService {
     story.user = Promise.resolve(user);
     await this.storyRepository.save(story);
 
-    if (badge) await this.userService.addBadgeExp({ badgeName: badge.badgeName, userId: userId, exp: 10 });
+    if (badge) await this.userService.addBadgeExp({ badgeName: badge.badgeName, userId: userId, exp: 100 });
     return { storyId: story.storyId, badge: { badgeEmoji: `${strToEmoji[story.badge.badgeName]}`, badgeName: story.badge.badgeName, prevExp: badge.badgeExp - 10, nowExp: badge.badgeExp } };
   }
 


### PR DESCRIPTION
## 🌁 배경
* close #680 

## ✅ 수정 내역
- 스토리 생성 시 경험치 100 제공으로 변경
